### PR TITLE
replace let with const for never reassigned variables

### DIFF
--- a/src/commands/askCommand.ts
+++ b/src/commands/askCommand.ts
@@ -32,7 +32,7 @@ export function askCommand(program: Command): void {
       if (options.file) {
         content.push(readMultipleFilesFromCurrentDir(options.file));
       }
-      let stringFromStdin = getStringFromStdin();
+      const stringFromStdin = getStringFromStdin();
       if (stringFromStdin) {
         content.push(stringFromStdin);
       }

--- a/src/commands/reviewCommand.ts
+++ b/src/commands/reviewCommand.ts
@@ -93,7 +93,7 @@ export function reviewCommand(program: Command): void {
       if (options.file) {
         content.push(readMultipleFilesFromCurrentDir(options.file));
       }
-      let stringFromStdin = getStringFromStdin();
+      const stringFromStdin = getStringFromStdin();
       if (stringFromStdin) {
         content.push(stringFromStdin);
       }


### PR DESCRIPTION
Replace variable declaration keywords to const for variables which values are not changed within the function/block at askCommand.ts and reviewCommand.ts