### PR TITLE
ci: allow integration tests to be triggered from a PR via labels

### DIFF
--- a/.github/workflows/integration-tests-platforms.yml
+++ b/.github/workflows/integration-tests-platforms.yml
@@ -2,9 +2,14 @@ name: Integration tests platforms
 
 on:
   workflow_dispatch:
+  # Manually schedulable from a PR by adding the `run-integration-tests-platforms` label.
+  # Re-add the label (remove then add) to re-run.
+  pull_request:
+    types: [labeled]
 
 jobs:
   integration-tests:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-integration-tests-platforms' }}
     runs-on: ubuntu-latest
     environment: integration tests
     permissions:

--- a/.github/workflows/integration-tests-small.yml
+++ b/.github/workflows/integration-tests-small.yml
@@ -2,9 +2,14 @@ name: Integration tests small
 
 on:
   workflow_dispatch:
+  # Manually schedulable from a PR by adding the `run-integration-tests-small` label.
+  # Re-add the label (remove then add) to re-run.
+  pull_request:
+    types: [labeled]
 
 jobs:
   integration-tests:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-integration-tests-small' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,9 +2,14 @@ name: Integration tests
 
 on:
   workflow_dispatch:
+  # Manually schedulable from a PR by adding the `run-integration-tests` label.
+  # Re-add the label (remove then add) to re-run.
+  pull_request:
+    types: [labeled]
 
 jobs:
   integration-tests:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-integration-tests' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -15,7 +20,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,18 @@ npm run it <provider> simple
 
 See [integration-tests/README.md](./integration-tests/README.md) for details.
 
+Integration tests run in CI on demand only. You can trigger them either from the
+**Actions** tab (the "Run workflow" button, via `workflow_dispatch`) or directly
+from a pull request by adding a label (a maintainer must apply it):
+
+| Label | Workflow |
+| --- | --- |
+| `run-integration-tests` | Integration tests (big single provider) |
+| `run-integration-tests-small` | Integration tests small (multi-provider, lite) |
+| `run-integration-tests-platforms` | Integration tests platforms (macOS/Windows) |
+
+The run executes against the PR's head commit. To re-run, remove and re-add the label.
+
 ## Test Conventions
 
 When working in `spec/`:


### PR DESCRIPTION
Add a pull_request: [labeled] trigger to all three integration-test workflows alongside the existing workflow_dispatch button. Each workflow runs only when its dedicated label is applied:

- run-integration-tests            -> integration-tests.yml
- run-integration-tests-small      -> integration-tests-small.yml
- run-integration-tests-platforms  -> integration-tests-platforms.yml

Runs check out the PR head commit. Document the labels in CONTRIBUTING.md.