### PR TITLE
fix(tui): TUI-C11 — debug-pane keybindings + Mac/compact-keyboard accessibility

### DIFF
--- a/docs/ux-guidelines.md
+++ b/docs/ux-guidelines.md
@@ -110,8 +110,10 @@ Tool calls render as **collapsible panels** (`tui/components/LiveTurn.tsx`):
 - **`Esc`** — abort the in-flight turn (only while running).
 - **`Ctrl+C`** — exit the app. (The bare `exit` keyword and `/exit` also quit.)
 - **`Ctrl+T`** — toggle tool-call detail mid-turn (mirrors `/tools`).
-- **`Tab`** — focus the docked debug panel when visible/idle; once focused, `Tab` cycles its views,
-  `PageUp`/`PageDown` scroll, `m` maximises, `Esc` unfocuses.
+- **`Tab`** — focus the docked debug panel when visible/idle; once focused, `Tab` cycles its views
+  (`Shift+Tab` reverses), `↑`/`↓` scroll one line and `PageUp`/`PageDown` page-step (arrows are the
+  documented scroll keys since Mac/compact keyboards lack dedicated `PageUp`/`PageDown` — DL-9, DL-5,
+  DL-7), `m` maximises, `Esc` unfocuses.
 - **arrows / Enter** — select / submit in the prompt.
 
 Defaults are beginner-safe (DL-9): tool detail collapsed, debug panel hidden — the expert opts into

--- a/packages/app/spec/tui/App.spec.tsx
+++ b/packages/app/spec/tui/App.spec.tsx
@@ -27,6 +27,9 @@ const ESC = String.fromCharCode(27); // Escape key byte
 const TAB = '\t'; // Tab key (char 9)
 const PAGE_DOWN = '\x1b[6~'; // PageDown CSI sequence
 const PAGE_UP = '\x1b[5~'; // PageUp CSI sequence
+const ARROW_DOWN = '\x1b[B'; // Down-arrow CSI sequence
+const ARROW_UP = '\x1b[A'; // Up-arrow CSI sequence
+const SHIFT_TAB = '\x1b[Z'; // Shift+Tab (back-tab) CSI sequence
 
 describe('tui <App>', () => {
   beforeEach(() => {
@@ -272,6 +275,136 @@ describe('tui <App>', () => {
     unmount();
   });
 
+  it('scrolls one line at a time with the ↑/↓ arrow keys while focused (TUI-C11)', async () => {
+    // Arrows give fine control (one line) on top of PgUp/PgDn's coarse page-step — and exist on
+    // every keyboard, unlike dedicated PgUp/PgDn on Mac/compact keyboards.
+    const longResult = Array.from({ length: 40 }, (_, i) => `line-${i}`).join('\n');
+    const agent = scriptedAgent([
+      { type: 'tool_start', id: 's1', name: 'task' },
+      { type: 'tool_args', id: 's1', delta: '{"subagent_type":"worker","description":"big"}' },
+      { type: 'tool_end', id: 's1' },
+      { type: 'tool_result', id: 's1', content: longResult },
+      { type: 'text', delta: 'ok' },
+    ]);
+    const { stdin, lastFrame, unmount } = render(
+      <App {...baseProps} agent={agent} initialMessage="go" />
+    );
+
+    await vi.waitFor(() => expect(lastFrame()).toContain('turns: 1'));
+    stdin.write('/debug');
+    await vi.waitFor(() => expect(lastFrame()).toContain('/debug'));
+    stdin.write('\r');
+    await vi.waitFor(() => expect(lastFrame()).toContain('worker'));
+
+    // The hint advertises the arrows as the scroll keys.
+    stdin.write(TAB);
+    await vi.waitFor(() => expect(lastFrame()).toContain('↑/↓: scroll'));
+
+    // Top of the list visible. Arrow-down a few lines: the top line scrolls out one at a time.
+    expect(lastFrame()).toContain('line-0');
+    for (let i = 0; i < 3; i++) stdin.write(ARROW_DOWN);
+    await vi.waitFor(() => {
+      const f = lastFrame() ?? '';
+      expect(f).not.toContain('line-0'); // top scrolled out by three single-line steps
+      expect(f).toContain('line-3'); // new top line
+    });
+
+    // Arrow-up returns toward the top one line at a time.
+    for (let i = 0; i < 3; i++) stdin.write(ARROW_UP);
+    await vi.waitFor(() => expect(lastFrame()).toContain('line-0'));
+
+    unmount();
+  });
+
+  it('clamps down-scroll to the end so PgUp/↑ recover immediately (no phantom offset) (TUI-C11)', async () => {
+    // Bug: PageDown had no upper clamp, so paging past the end inflated the offset; afterwards
+    // PgUp/↑ had to burn through that phantom offset before anything moved. The clamp pins the
+    // offset to its real max, so a single PgUp/↑ visibly scrolls back from the end.
+    const longResult = Array.from({ length: 40 }, (_, i) => `row-${i}`).join('\n');
+    const agent = scriptedAgent([
+      { type: 'tool_start', id: 's1', name: 'task' },
+      { type: 'tool_args', id: 's1', delta: '{"subagent_type":"worker","description":"big"}' },
+      { type: 'tool_end', id: 's1' },
+      { type: 'tool_result', id: 's1', content: longResult },
+      { type: 'text', delta: 'ok' },
+    ]);
+    const { stdin, lastFrame, unmount } = render(
+      <App {...baseProps} agent={agent} initialMessage="go" />
+    );
+
+    await vi.waitFor(() => expect(lastFrame()).toContain('turns: 1'));
+    stdin.write('/debug');
+    await vi.waitFor(() => expect(lastFrame()).toContain('/debug'));
+    stdin.write('\r');
+    await vi.waitFor(() => expect(lastFrame()).toContain('worker'));
+
+    stdin.write(TAB);
+    await vi.waitFor(() => expect(lastFrame()).toContain('↑/↓: scroll'));
+
+    // Over-page well past the end. With the clamp the offset pins to its real maximum, so the
+    // footer reads "— end —" (last line in view) and never a phantom range beyond the content.
+    for (let i = 0; i < 20; i++) stdin.write(PAGE_DOWN);
+    const lastLine = `row-${40 - 1}`;
+    await vi.waitFor(() => {
+      const f = lastFrame() ?? '';
+      expect(f).toContain(lastLine); // the genuine last line is in view
+      expect(f).toContain('— end —'); // footer marks the real end (no over-scroll)
+    });
+
+    // A single PgUp moves immediately (no phantom offset to burn through): the last line leaves
+    // view and the "more below" marker returns.
+    stdin.write(PAGE_UP);
+    await vi.waitFor(() => {
+      const f = lastFrame() ?? '';
+      expect(f).not.toContain(lastLine);
+      expect(f).toContain('more below');
+    });
+
+    unmount();
+  });
+
+  it('cycles debug sections backward with Shift+Tab (TUI-C11)', async () => {
+    // Plain Tab steps forward (subagents → history → request → response); Shift+Tab steps back.
+    // From the first section, one Shift+Tab wraps to the last (response).
+    const agent = scriptedAgent([{ type: 'text', delta: 'hi' }]);
+    let emit: ((c: import('#src/tui/types.js').TuiDebugCapture) => void) | undefined;
+    const subscribeDebug = (cb: (c: import('#src/tui/types.js').TuiDebugCapture) => void) => {
+      emit = cb;
+      return () => {};
+    };
+    const { stdin, lastFrame, unmount } = render(
+      <App {...baseProps} agent={agent} subscribeDebug={subscribeDebug} />
+    );
+
+    await vi.waitFor(() => expect(lastFrame()).toContain('>'));
+    // Distinct content per section so we can tell which tab's body is shown.
+    emit?.({ kind: 'request', text: 'HISTORY_BODY', details: 'REQUEST_BODY' });
+    emit?.({ kind: 'response', text: 'RESPONSE_BODY' });
+
+    stdin.write('/debug');
+    await vi.waitFor(() => expect(lastFrame()).toContain('/debug'));
+    stdin.write('\r');
+    await vi.waitFor(() => expect(lastFrame()).toContain('Subagents'));
+
+    stdin.write(TAB); // focus (starts on the subagents section)
+    await vi.waitFor(() => expect(lastFrame()).toContain('Tab: section'));
+    await vi.waitFor(() => expect(lastFrame()).toContain('(no subagents spawned yet)'));
+
+    // Shift+Tab from the first section wraps backward to the last (response).
+    stdin.write(SHIFT_TAB);
+    await vi.waitFor(() => expect(lastFrame()).toContain('RESPONSE_BODY'));
+
+    // Shift+Tab again steps back one more to the request section.
+    stdin.write(SHIFT_TAB);
+    await vi.waitFor(() => expect(lastFrame()).toContain('REQUEST_BODY'));
+
+    // Plain Tab still goes forward — back to the response section.
+    stdin.write(TAB);
+    await vi.waitFor(() => expect(lastFrame()).toContain('RESPONSE_BODY'));
+
+    unmount();
+  });
+
   it('maximises and restores the focused debug panel with the "m" key', async () => {
     // A subagent result long enough to overflow the default 8-row viewport but fit a maximised one.
     const longResult = Array.from({ length: 20 }, (_, i) => `row-${i}`).join('\n');
@@ -489,7 +622,9 @@ describe('tui <App>', () => {
 
     // Second /tools toggles back to off, again with a confirming notice.
     stdin.write('/tools');
-    await vi.waitFor(() => expect((lastFrame() ?? '').match(/\/tools/g)?.length).toBeGreaterThan(0));
+    await vi.waitFor(() =>
+      expect((lastFrame() ?? '').match(/\/tools/g)?.length).toBeGreaterThan(0)
+    );
     stdin.write('\r');
     await vi.waitFor(() => expect(frames.join('\n')).toContain('Tool details: off'));
 
@@ -514,7 +649,9 @@ describe('tui <App>', () => {
     });
 
     stdin.write('/model');
-    await vi.waitFor(() => expect((lastFrame() ?? '').match(/\/model/g)?.length).toBeGreaterThan(0));
+    await vi.waitFor(() =>
+      expect((lastFrame() ?? '').match(/\/model/g)?.length).toBeGreaterThan(0)
+    );
     stdin.write('\r');
     await vi.waitFor(() => {
       const all = frames.join('\n');
@@ -537,7 +674,9 @@ describe('tui <App>', () => {
     await vi.waitFor(() => expect(frames.join('\n')).toContain('Debug panel: shown'));
 
     stdin.write('/debug');
-    await vi.waitFor(() => expect((lastFrame() ?? '').match(/\/debug/g)?.length).toBeGreaterThan(0));
+    await vi.waitFor(() =>
+      expect((lastFrame() ?? '').match(/\/debug/g)?.length).toBeGreaterThan(0)
+    );
     stdin.write('\r');
     await vi.waitFor(() => expect(frames.join('\n')).toContain('Debug panel: hidden'));
 
@@ -632,9 +771,7 @@ describe('tui <App>', () => {
       { type: 'text', delta: '# Heading\n' },
       { type: 'text', delta: '- bullet point' },
     ]);
-    const { lastFrame, unmount } = render(
-      <App {...baseProps} agent={agent} initialMessage="go" />
-    );
+    const { lastFrame, unmount } = render(<App {...baseProps} agent={agent} initialMessage="go" />);
 
     await vi.waitFor(() => {
       const f = lastFrame() ?? '';

--- a/packages/app/src/tui/components/App.tsx
+++ b/packages/app/src/tui/components/App.tsx
@@ -15,7 +15,12 @@ import { StatusBar } from '#src/tui/components/StatusBar.js';
 import { PromptInput } from '#src/tui/components/PromptInput.js';
 import { Rule } from '#src/tui/components/Rule.js';
 import { ClearBanner } from '#src/tui/components/ClearBanner.js';
-import { DebugPanel, DEBUG_TABS, type DebugTab } from '#src/tui/components/DebugPanel.js';
+import {
+  DebugPanel,
+  debugPanelLines,
+  DEBUG_TABS,
+  type DebugTab,
+} from '#src/tui/components/DebugPanel.js';
 import {
   createCommandRegistry,
   dispatchSlashCommand,
@@ -98,6 +103,25 @@ export function App(props: TuiAppProps): React.ReactElement {
   const debugViewport = debugViewportHeight(debugMaximized, terminalRows);
   // PageUp/PageDown step tracks the live viewport so maximise pages by (almost) a full screen.
   const debugPageStep = Math.max(1, debugViewport - 1);
+  // The active section's line count drives the real maximum scroll offset, so neither the page
+  // step nor the arrow step can push the offset past the end (the over-scroll bug that left
+  // PgUp/↑ burning through phantom offset before anything moved — TUI-C11). Single-sourced with
+  // DebugPanel via the exported `debugPanelLines` so the clamp matches exactly what is rendered.
+  const debugLineCount = useMemo(
+    () =>
+      debugPanelLines({
+        subagents,
+        historyLines: debugHistory,
+        requestLines: debugRequest,
+        responseLines: debugResponse,
+        activeTab: debugTab,
+      }).length,
+    [subagents, debugHistory, debugRequest, debugResponse, debugTab]
+  );
+  const debugMaxOffset = Math.max(0, debugLineCount - debugViewport);
+  // Clamp helper shared by every downward scroll (page + arrow) so the offset never exceeds the
+  // real maximum; the upward floor stays Math.max(0, …).
+  const clampDebugScroll = (next: number) => Math.min(Math.max(0, next), debugMaxOffset);
 
   // Built once per session; a plain array so later layers (EXT-5) could append commands.
   const registry = useMemo(() => createCommandRegistry(), []);
@@ -262,7 +286,8 @@ export function App(props: TuiAppProps): React.ReactElement {
   //  1. Esc while running → abort the in-flight turn (stdin is uncontended here — the event
   //     path never registers gsloth's readline Esc handler, so Ink owns raw mode cleanly).
   //  2. Tab while the panel is visible and idle → focus/cycle the panel.
-  //  3. While the panel is focused → Tab cycles section, PageUp/PageDown scroll, Esc unfocuses.
+  //  3. While the panel is focused → Tab/Shift+Tab cycle sections, ↑/↓ scroll one line,
+  //     PageUp/PageDown page-step, m maximises, Esc unfocuses.
   useInput((input, key) => {
     if (key.escape && runningRef.current) {
       abortRef.current?.abort();
@@ -285,8 +310,13 @@ export function App(props: TuiAppProps): React.ReactElement {
         debugFocusedRef.current = false;
         return;
       }
+      // Tab cycles sections forward; Shift+Tab steps back to the previous section (Ink reports
+      // a back-tab as key.tab with key.shift). Both reset the scroll to the top of the new section.
       if (key.tab) {
-        setDebugTab((t) => DEBUG_TABS[(DEBUG_TABS.indexOf(t) + 1) % DEBUG_TABS.length]);
+        const step = key.shift ? -1 : 1;
+        setDebugTab(
+          (t) => DEBUG_TABS[(DEBUG_TABS.indexOf(t) + step + DEBUG_TABS.length) % DEBUG_TABS.length]
+        );
         setDebugScroll(0);
         return;
       }
@@ -296,12 +326,24 @@ export function App(props: TuiAppProps): React.ReactElement {
         setDebugMaximized((m) => !m);
         return;
       }
+      // ↑/↓ scroll one line for fine control; PgUp/PgDn page-step for coarse. Arrows exist on
+      // every keyboard, so they are the universal scroll keys (Mac/compact keyboards lack
+      // dedicated PgUp/PgDn) — that is why the hint and overflow markers advertise the arrows
+      // (TUI-C11). Every downward move is clamped to the real maximum (see clampDebugScroll).
+      if (key.upArrow) {
+        setDebugScroll((s) => Math.max(0, s - 1));
+        return;
+      }
+      if (key.downArrow) {
+        setDebugScroll((s) => clampDebugScroll(s + 1));
+        return;
+      }
       if (key.pageUp) {
         setDebugScroll((s) => Math.max(0, s - debugPageStep));
         return;
       }
       if (key.pageDown) {
-        setDebugScroll((s) => s + debugPageStep);
+        setDebugScroll((s) => clampDebugScroll(s + debugPageStep));
         return;
       }
       return;

--- a/packages/app/src/tui/components/DebugPanel.tsx
+++ b/packages/app/src/tui/components/DebugPanel.tsx
@@ -34,6 +34,42 @@ export interface DebugPanelProps {
   maximized: boolean;
 }
 
+/** The data a debug section needs to resolve into renderable lines. */
+export interface DebugPanelLinesInput {
+  subagents: SubagentTreeViewModel;
+  historyLines: string[];
+  requestLines: string[];
+  responseLines: string[];
+  activeTab: DebugTab;
+}
+
+/**
+ * The exact lines the active section renders, including the empty-state placeholders. Exported
+ * (and pure) so `<App>` can compute the active section's length to clamp the scroll offset to
+ * its real maximum — keeping keyboard scrolling and the rendered viewport in agreement (TUI-C11).
+ */
+export function debugPanelLines({
+  subagents,
+  historyLines,
+  requestLines,
+  responseLines,
+  activeTab,
+}: DebugPanelLinesInput): string[] {
+  return activeTab === 'subagents'
+    ? subagentLines(subagents)
+    : activeTab === 'history'
+      ? historyLines.length
+        ? historyLines
+        : ['(no model call captured yet)']
+      : activeTab === 'request'
+        ? requestLines.length
+          ? requestLines
+          : ['(no request details captured yet)']
+        : responseLines.length
+          ? responseLines
+          : ['(no model response captured yet)'];
+}
+
 /** Flatten the subagent tree into renderable lines for the bounded viewport. */
 function subagentLines(tree: SubagentTreeViewModel): string[] {
   if (tree.nodes.length === 0) return ['(no subagents spawned yet)'];
@@ -68,20 +104,13 @@ export function DebugPanel({
   viewportHeight,
   maximized,
 }: DebugPanelProps): React.ReactElement {
-  const lines =
-    activeTab === 'subagents'
-      ? subagentLines(subagents)
-      : activeTab === 'history'
-        ? historyLines.length
-          ? historyLines
-          : ['(no model call captured yet)']
-        : activeTab === 'request'
-          ? requestLines.length
-            ? requestLines
-            : ['(no request details captured yet)']
-          : responseLines.length
-            ? responseLines
-            : ['(no model response captured yet)'];
+  const lines = debugPanelLines({
+    subagents,
+    historyLines,
+    requestLines,
+    responseLines,
+    activeTab,
+  });
 
   // Clamp the window into range so an offset left over from a longer section never blanks
   // the viewport when switching to a shorter one.
@@ -98,8 +127,8 @@ export function DebugPanel({
   // line range, an "N more below" / "— end —" marker, and an "▲ above" marker when scrolled.
   const footer = overflow
     ? `${top + 1}-${bottom}/${lines.length}` +
-      (hasBelow ? `  ▼ ${lines.length - bottom} more below (PgDn)` : '  — end —') +
-      (hasAbove ? '  ▲ above (PgUp)' : '')
+      (hasBelow ? `  ▼ ${lines.length - bottom} more below (↓)` : '  — end —') +
+      (hasAbove ? '  ▲ above (↑)' : '')
     : `${lines.length} line${lines.length === 1 ? '' : 's'}`;
 
   return (
@@ -125,7 +154,7 @@ export function DebugPanel({
       <Box>
         <Text dimColor>
           {focused
-            ? `[Tab: section · PgUp/PgDn: scroll · m: ${
+            ? `[Tab: section · ↑/↓: scroll · m: ${
                 maximized ? 'restore' : 'maximise'
               } · Esc: unfocus]`
             : '[/debug to hide]'}


### PR DESCRIPTION
Closes **TUI-C11**. Three fixes to the docked `/debug` panel (TUI-C2), all in `packages/app/`.

## Changes
- **Mac/compact-keyboard accessibility** (reported by designer): `↑`/`↓` now line-scroll the focused debug panel; `PgUp`/`PgDn` remain the page-step (they don't exist as dedicated keys on most Mac laptops / compact keyboards — `Fn+↑/↓` emits the same codes, so the old `PgUp/PgDn` hint was undiscoverable). Hint row relabelled to `[Tab: section · ↑/↓: scroll · m: … · Esc: unfocus]`; footer markers `(PgDn)`/`(PgUp)` → `(↓)`/`(↑)`.
- **Scroll-bounds bug**: scroll offset is now clamped to `max(0, lineCount − viewport)` for both arrow-down and PgDn via a shared pure `debugPanelLines()` helper, so over-paging no longer inflates the offset and `PgUp` recovers immediately (was: "PgUp stops scrolling at the last tab").
- **Reverse tab cycle**: `Shift+Tab` cycles debug tabs backward (plain `Tab` still forward).

## Verification
- `pnpm build` clean
- `pnpm unit` — **821 passed** (+3 new tests in `App.spec.tsx` covering arrow scroll, the clamp, and Shift+Tab)
- `pnpm it-tui` — **6/6** PTY e2e

Also updates `docs/ux-guidelines.md` keyboard section (DL-9 rationale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
