### PR TITLE
ci(review): fix AI review — install published CLI with npm, not pnpm (OPS-6 regression)

### DIFF
--- a/.github/workflows/_review-shared.yml
+++ b/.github/workflows/_review-shared.yml
@@ -43,17 +43,19 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - name: Enable Corepack
-        run: corepack enable
-
       - name: Use Node.js 24.x
         uses: actions/setup-node@v6
         with:
           node-version: 24.x
-          cache: 'pnpm'
 
-      - name: Install dependencies
-        run: pnpm add -g @gaunt-sloth/review@0.1.8 @langchain/google && gaunt-sloth-review --version
+      # Install the PUBLISHED review CLI globally. Keep this on npm, not pnpm:
+      # `pnpm add -g` drops bins in pnpm's global bin dir, which is not on PATH
+      # without `pnpm setup` (not run on CI runners) — so `gaunt-sloth-review`
+      # was not found post-OPS-6. npm's global bin is on PATH by default. There
+      # is no repo/workspace install here (published package only), so corepack
+      # and the pnpm cache are unnecessary.
+      - name: Install gaunt-sloth-review
+        run: npm i -g @gaunt-sloth/review@0.1.8 @langchain/google && gaunt-sloth-review --version
 
       - name: Extract issue number from PR title
         id: extract_issue


### PR DESCRIPTION
The AI PR-review workflow broke after the OPS-6 pnpm flip.

## Problem
`_review-shared.yml` installed the review CLI with `pnpm add -g @gaunt-sloth/review@0.1.8 …`, but pnpm's global bin dir (`~/.local/share/pnpm/bin`) isn't on PATH without `pnpm setup`, which CI runners don't run:

```
The configured global bin directory "/home/runner/.local/share/pnpm/bin" is not in PATH
Run "pnpm setup" to update your shell configuration.
Error: Process completed with exit code 1.
```

## Fix
Install with **`npm i -g`** instead of `pnpm add -g` — npm's global bin is on PATH by default. This step only installs the *published* `@gaunt-sloth/review` package (no repo/workspace install), so it should stay on npm — consistent with the OPS-6 decision to keep published-install lines on npm. Dropped the now-unnecessary `corepack enable` + `cache: 'pnpm'`.

Version pin stays at `0.1.8` here; the bump to the latest alpha is split into a separate stacked PR (#379).

## ⚠️ Verifying
This workflow runs via `pull_request_target`, which runs the workflow from `main`, not the PR (deliberate — see the file header). So this PR's own AI-review check still runs the broken `main` version; the fix only takes effect once merged, visible on the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)