### PR TITLE
ci(review): bump @gaunt-sloth/review pin 0.1.8 → 2.0.0-alpha.1 (latest alpha)

### DIFF
--- a/.github/workflows/_review-shared.yml
+++ b/.github/workflows/_review-shared.yml
@@ -55,7 +55,7 @@ jobs:
       # is no repo/workspace install here (published package only), so corepack
       # and the pnpm cache are unnecessary.
       - name: Install gaunt-sloth-review
-        run: npm i -g @gaunt-sloth/review@0.1.8 @langchain/google && gaunt-sloth-review --version
+        run: npm i -g @gaunt-sloth/review@2.0.0-alpha.1 @langchain/google && gaunt-sloth-review --version
 
       - name: Extract issue number from PR title
         id: extract_issue


### PR DESCRIPTION
Bumps the review CLI pin to the latest published alpha (`2.0.0-alpha.1`, npm dist-tag `alpha`).

Pinned exact rather than tracking the moving `alpha` tag, to keep CI reproducible.

**Stacked on #378** (base is `node/review-yml-npm`, not `main`) because both edits touch the same install line — this PR shows only the version diff. GitHub will auto-retarget it to `main` once #378 merges; merge #378 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
