### PR TITLE
fix(release): tolerate bare `--` separator in bump.mjs

### DIFF
--- a/bump.mjs
+++ b/bump.mjs
@@ -48,7 +48,10 @@ const RELEASE_TYPES = [
 ];
 const PREIDS = ['alpha', 'beta', 'rc'];
 
-const args = process.argv.slice(2).filter((a) => a !== '--commit');
+// Drop our own `--commit` flag and any bare `--` arg-separator. pnpm forwards
+// the `--` from `pnpm run <script> -- <args>` literally into argv (npm strips
+// it), so without this a `--` would be parsed as the version spec.
+const args = process.argv.slice(2).filter((a) => a !== '--commit' && a !== '--');
 const commit = process.argv.slice(2).includes('--commit');
 
 // Arg shapes:


### PR DESCRIPTION
## Summary

The Release workflow's post-publish bump step ran `pnpm run release:bump-and-commit -- "$BUMP" "$PREID"`, which expands to `node bump.mjs --commit -- <bump> <preid>`. Since the repo migrated to **pnpm 11**, pnpm forwards the literal `--` arg-separator into the script (npm strips it), so argv became `['--commit', '--', <bump>, <preid>]`. `bump.mjs` filtered out only `--commit`, leaving `--` as `args[0]` and failing with:

```
Bad version: --. Expected one of [patch | minor | major | prepatch | preminor | premajor | prerelease]
or an explicit MAJOR.MINOR.PATCH[-prerelease].
```

## Fix

Filter out the bare `--` alongside `--commit` so the script is robust under both npm (which strips `--`) and pnpm (which forwards it):

```diff
-const args = process.argv.slice(2).filter((a) => a !== '--commit');
+const args = process.argv.slice(2).filter((a) => a !== '--commit' && a !== '--');
```

## Verification

With deps installed via pnpm, both invocation shapes now resolve correctly (previously errored with "Bad version: --"):

- `node bump.mjs -- prerelease alpha` → `Syncing all four packages to 2.0.0-alpha.3 ...`
- `node bump.mjs -- 2.0.0-rc.1` → `Syncing all four packages to 2.0.0-rc.1 ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbHftpzuHWrkVSJRHerdZt)_