### PR TITLE
feat(agent): add gated run_shell_command bash tool with confirmation (EXT-9)

### DIFF
--- a/packages/agent/spec/GthDeepAgent.spec.ts
+++ b/packages/agent/spec/GthDeepAgent.spec.ts
@@ -350,6 +350,60 @@ describe('GthDeepAgent', () => {
     expect(createDeepAgentMock.mock.calls[0][0].tools).toEqual([]);
   });
 
+  it('does not set interruptOn when the shell tool is not enabled', async () => {
+    const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
+    const agent = new GthDeepAgent(statusUpdate, { resolveTools: vi.fn().mockResolvedValue([]) });
+
+    await agent.init('code', makeConfig());
+
+    expect(createDeepAgentMock.mock.calls[0][0].interruptOn).toBeUndefined();
+  });
+
+  it('sets interruptOn for run_shell_command when shell is enabled and yolo is off', async () => {
+    const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
+    const agent = new GthDeepAgent(statusUpdate, { resolveTools: vi.fn().mockResolvedValue([]) });
+    const config = makeConfig({
+      commands: { code: { devTools: { shell: true } } } as any,
+    });
+
+    await agent.init('code', config);
+
+    expect(createDeepAgentMock.mock.calls[0][0].interruptOn).toEqual({
+      run_shell_command: { allowedDecisions: ['approve', 'reject'] },
+    });
+  });
+
+  it('omits interruptOn under yolo (shell enabled, shellYolo true) so the tool runs unconfirmed', async () => {
+    const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
+    const agent = new GthDeepAgent(statusUpdate, { resolveTools: vi.fn().mockResolvedValue([]) });
+    const config = makeConfig({
+      commands: { code: { devTools: { shell: true, shellYolo: true } } } as any,
+    });
+
+    await agent.init('code', config);
+
+    expect(createDeepAgentMock.mock.calls[0][0].interruptOn).toBeUndefined();
+    // And it warns loudly about the bypass.
+    expect(statusUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('YOLO mode')
+    );
+  });
+
+  it('reads the exec command devTools for the interrupt wiring', async () => {
+    const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
+    const agent = new GthDeepAgent(statusUpdate, { resolveTools: vi.fn().mockResolvedValue([]) });
+    const config = makeConfig({
+      commands: { exec: { devTools: { shell: true } } } as any,
+    });
+
+    await agent.init('exec', config);
+
+    expect(createDeepAgentMock.mock.calls[0][0].interruptOn).toEqual({
+      run_shell_command: { allowedDecisions: ['approve', 'reject'] },
+    });
+  });
+
   it('stubs client config tools (clones, swapping the body for interrupt)', async () => {
     const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
     const clientTool = fakeTool('client_tool', { client: true });

--- a/packages/agent/spec/GthDevToolkit.simple.spec.ts
+++ b/packages/agent/spec/GthDevToolkit.simple.spec.ts
@@ -108,6 +108,45 @@ describe('GthDevToolkit - Basic Tests', () => {
     });
   });
 
+  describe('run_shell_command (opt-in shell tool)', () => {
+    it('is NOT emitted by default (shell omitted)', () => {
+      toolkit = new GthDevToolkit({ run_tests: 'npm test' });
+      expect(toolkit.tools.map((t) => t.name)).not.toContain('run_shell_command');
+    });
+
+    it('is NOT emitted when shell is false', () => {
+      toolkit = new GthDevToolkit({ shell: false });
+      expect(toolkit.tools.map((t) => t.name)).not.toContain('run_shell_command');
+    });
+
+    it('is emitted when shell is true (bare boolean)', () => {
+      toolkit = new GthDevToolkit({ shell: true });
+      const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command');
+      expect(shellTool).toBeDefined();
+      expect((shellTool as any).gthDevType).toBe('execute');
+    });
+
+    it('is emitted when shell is { enabled: true } (object form)', () => {
+      toolkit = new GthDevToolkit({ shell: { enabled: true } });
+      expect(toolkit.tools.map((t) => t.name)).toContain('run_shell_command');
+    });
+
+    it('is NOT emitted when shell is { enabled: false }', () => {
+      toolkit = new GthDevToolkit({ shell: { enabled: false } });
+      expect(toolkit.tools.map((t) => t.name)).not.toContain('run_shell_command');
+    });
+
+    it('runs the model-supplied command verbatim (no parameter sanitizing)', async () => {
+      toolkit = new GthDevToolkit({ shell: true });
+      const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command')!;
+      // A legitimate shell command with a pipe + $ — would be rejected by the path sanitizer,
+      // but the shell tool must pass it through (confirmation, not filtering, is the guardrail).
+      const result = await shellTool.invoke({ command: 'echo $HOME | cat' });
+      expect(result).toContain("Command 'echo $HOME | cat' completed successfully");
+      expect(childProcessMock.spawn).toHaveBeenCalledWith('echo $HOME | cat', { shell: true });
+    });
+  });
+
   describe('buildSingleTestCommand', () => {
     it('should build command with placeholder', () => {
       toolkit = new GthDevToolkit({ run_single_test: 'npm test -- ${testPath}' });

--- a/packages/agent/src/core/GthDeepAgent.ts
+++ b/packages/agent/src/core/GthDeepAgent.ts
@@ -1,4 +1,5 @@
-import type { GthConfig } from '@gaunt-sloth/core/config.js';
+import type { GthConfig, GthDevToolsConfig } from '@gaunt-sloth/core/config.js';
+import { isShellToolEnabled } from '@gaunt-sloth/core/config.js';
 import { GthAbstractAgent } from '@gaunt-sloth/core/core/GthAbstractAgent.js';
 import { type GthCommand, StatusLevel } from '@gaunt-sloth/core/core/types.js';
 import { debugLog, debugLogObject } from '@gaunt-sloth/core/utils/debugUtils.js';
@@ -13,7 +14,7 @@ import { getCurrentWorkDir } from '@gaunt-sloth/core/utils/systemUtils.js';
 import { AIMessage, ToolMessage } from '@langchain/core/messages';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { BaseCheckpointSaver } from '@langchain/langgraph';
-import { createMiddleware } from 'langchain';
+import { createMiddleware, type InterruptOnConfig } from 'langchain';
 import { createDeepAgent, FilesystemBackend } from 'deepagents';
 import {
   buildPermissions,
@@ -50,6 +51,18 @@ export interface GthDeepAgentParams {
    * no prompt content is composed (lets deepagents use only its base prompt).
    */
   systemPrompt: string | undefined;
+  /**
+   * Per-tool human-in-the-loop configuration passed straight to
+   * `createDeepAgent({ interruptOn })` (deepagents installs LangChain's
+   * `humanInTheLoopMiddleware` for it). A matching tool call suspends the graph with a
+   * `__interrupt__` (a `HITLRequest`) so a consumer can approve/reject before the tool runs;
+   * resume with `new Command({ resume: { decisions: [...] } })` on the same `thread_id`.
+   *
+   * gsloth currently sets this only for the opt-in `run_shell_command` tool (when its
+   * `devTools.shell` is enabled and `devTools.shellYolo` is NOT). Left `undefined` otherwise —
+   * including under yolo — so no tool is gated and runs never suspend for approval.
+   */
+  interruptOn?: Record<string, boolean | InterruptOnConfig>;
 }
 
 /**
@@ -172,6 +185,10 @@ export class GthDeepAgent extends GthAbstractAgent {
       middleware: middleware as any,
       backend,
       permissions: params.permissions,
+      // Per-tool human-in-the-loop gating (e.g. run_shell_command confirmation). When set,
+      // deepagents installs humanInTheLoopMiddleware so a matching tool call suspends the graph
+      // for approval; `undefined` (the default, and under yolo) leaves every tool ungated.
+      interruptOn: params.interruptOn,
       checkpointer,
     });
     debugLog('Deep agent created successfully');
@@ -353,13 +370,58 @@ export class GthDeepAgent extends GthAbstractAgent {
     const systemPrompt =
       typeof systemMessages[0]?.content === 'string' ? systemMessages[0].content : undefined;
 
+    // Gate the opt-in run_shell_command tool behind a per-command approval interrupt. The tool
+    // is only emitted (by GthDevToolkit, via builtInToolsConfig) when its devTools.shell flag is
+    // set; mirror the same per-command devTools resolution here so the interrupt is wired only
+    // when the tool actually exists. yolo (shellYolo) opts OUT of the confirmation: leave
+    // interruptOn undefined so the tool runs without suspending.
+    const devTools = this.getEffectiveDevToolsConfig();
+    const interruptOn =
+      isShellToolEnabled(devTools) && devTools?.shellYolo !== true
+        ? ({ run_shell_command: { allowedDecisions: ['approve', 'reject'] } } as Record<
+            string,
+            boolean | InterruptOnConfig
+          >)
+        : undefined;
+    if (interruptOn) {
+      this.statusUpdate(
+        StatusLevel.INFO,
+        'Shell tool (run_shell_command) enabled with per-command approval (interruptOn).'
+      );
+    } else if (isShellToolEnabled(devTools)) {
+      this.statusUpdate(
+        StatusLevel.WARNING,
+        'Shell tool (run_shell_command) enabled in YOLO mode: commands run WITHOUT confirmation.'
+      );
+    }
+
     return {
       model: this.config.llm,
       tools: passThroughTools as StructuredToolInterface[],
       permissions,
       middleware,
       systemPrompt,
+      interruptOn,
     };
+  }
+
+  /**
+   * Resolve the {@link GthDevToolsConfig} that applies to the active command, mirroring the
+   * per-command selection in `builtInToolsConfig.getDefaultTools` (which is what actually emits
+   * the dev tools): `exec` → `commands.exec.devTools`, `ask --write` → `commands.ask.devTools`,
+   * otherwise (`code`) → `commands.code.devTools`. Returns `undefined` for any other command,
+   * matching the toolkit being inert there. Kept private and side-effect-free so the interrupt
+   * wiring above and the tool emission stay in lockstep.
+   */
+  private getEffectiveDevToolsConfig(): GthDevToolsConfig | undefined {
+    const config = this.config;
+    if (!config) return undefined;
+    const command = this.command;
+    const askWrite = command === 'ask' && config.askWriteMode === true;
+    if (command === 'exec') return config.commands?.exec?.devTools;
+    if (askWrite) return config.commands?.ask?.devTools;
+    if (command === 'code') return config.commands?.code?.devTools;
+    return undefined;
   }
 }
 

--- a/packages/agent/src/modules/interactiveSessionModule.ts
+++ b/packages/agent/src/modules/interactiveSessionModule.ts
@@ -3,6 +3,7 @@ import {
   defaultStatusCallback,
   display,
   displayInfo,
+  displayWarning,
   flushSessionLog,
   formatInputPrompt,
   initSessionLogging,
@@ -50,6 +51,29 @@ export async function createInteractiveSession(
     await runner.init(sessionConfig.mode, config, checkpointSaver);
     const rl = createInterface({ input, output });
     let shouldExit = false;
+
+    // Tool-approval (human-in-the-loop) prompt for gated tools — currently the opt-in
+    // `run_shell_command`. When a run suspends on such a tool call, the runner calls this with
+    // the pending command; a simple readline y/n confirm gates execution. Anything other than an
+    // explicit "y"/"yes" rejects (fail-closed). The model gets a tool-rejected message on reject
+    // and continues. (The Ink TUI path does not yet surface this prompt — see EXT-9 report.)
+    runner.setToolApprovalCallback(async (pending) => {
+      const commandText =
+        typeof pending.args.command === 'string'
+          ? (pending.args.command as string)
+          : JSON.stringify(pending.args);
+      displayWarning(`\nThe agent wants to run a shell command via ${pending.name}:`);
+      display(`\n    ${commandText}\n`);
+      setRawMode(false); // ensure typed input is echoed for this confirm
+      const answer = await rl.question(formatInputPrompt('Run this command? (y/N): '));
+      const approved = answer.trim().toLowerCase().startsWith('y');
+      if (!approved) {
+        displayInfo('Command rejected.');
+      }
+      return approved
+        ? { type: 'approve' }
+        : { type: 'reject', message: 'User rejected the shell command.' };
+    });
 
     if (logFileName) {
       displayInfo(`${sessionConfig.mode} session will be logged to ${logFileName}\n`);

--- a/packages/agent/src/tools/GthDevToolkit.ts
+++ b/packages/agent/src/tools/GthDevToolkit.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { spawn } from 'child_process';
 import path from 'node:path';
 import { displayInfo, displayError } from '@gaunt-sloth/core/utils/consoleUtils.js';
-import { GthDevToolsConfig } from '@gaunt-sloth/core/config.js';
+import { GthDevToolsConfig, isShellToolEnabled } from '@gaunt-sloth/core/config.js';
 import { stdout } from '@gaunt-sloth/core/utils/systemUtils.js';
 
 // Helper function to create a tool with dev type
@@ -31,6 +31,9 @@ const RunLintArgsSchema = z.object({});
 const RunBuildArgsSchema = z.object({});
 const RunSingleTestArgsSchema = z.object({
   testPath: z.string().describe('Relative path to the test file to run'),
+});
+const RunShellCommandArgsSchema = z.object({
+  command: z.string().describe('The shell command to run'),
 });
 
 const TEST_PATH_PLACEHOLDER = '${testPath}';
@@ -244,6 +247,30 @@ export default class GthDevToolkit extends BaseToolkit {
               'Build the project. Executes the configured build command and returns the build output.' +
               `\nThe configured command is [${this.commands.run_build!}].`,
             schema: RunBuildArgsSchema,
+          },
+          'execute'
+        )
+      );
+    }
+
+    // Opt-in general-purpose shell tool. Unlike the fixed run_* commands, the model supplies
+    // the command, so the guardrail is the per-command confirmation dialog wired by the deep
+    // agent (createDeepAgent `interruptOn`), not a parameter sanitizer — a real shell command
+    // legitimately contains pipes / `$` / `;`, so validateParameterValue must NOT be applied.
+    if (isShellToolEnabled(this.commands)) {
+      tools.push(
+        createGthTool(
+          async (args: z.infer<typeof RunShellCommandArgsSchema>): Promise<string> => {
+            return await this.executeCommand(args.command, 'run_shell_command');
+          },
+          {
+            name: 'run_shell_command',
+            description:
+              'Run an arbitrary shell command in the project working directory and return its ' +
+              'combined stdout/stderr and exit status. Use for any task the fixed run_* tools do ' +
+              'not cover (e.g. git, package managers, file inspection). Each call is subject to ' +
+              'human approval before it runs unless approval has been disabled.',
+            schema: RunShellCommandArgsSchema,
           },
           'execute'
         )

--- a/packages/app/spec/codeCommand.spec.ts
+++ b/packages/app/spec/codeCommand.spec.ts
@@ -94,6 +94,7 @@ const gthAgentRunnerMock = vi.fn(function GthAgentRunnerMock() {
 const gthAgentRunnerInstanceMock = {
   init: vi.fn(),
   processMessages: vi.fn(),
+  setToolApprovalCallback: vi.fn(),
   cleanup: vi.fn(),
 };
 vi.mock('#src/core/GthAgentRunner.js', () => ({

--- a/packages/core/spec/GthAgentRunner.spec.ts
+++ b/packages/core/spec/GthAgentRunner.spec.ts
@@ -71,6 +71,10 @@ describe('GthAgentRunner', () => {
     mockAgent.stream.mockClear();
     mockAgent.streamWithEvents.mockClear();
     mockAgent.cleanup.mockClear();
+    // The HITL interrupt methods are added per-test on the shared mock; remove any that leaked
+    // from a previous test so unrelated cases see an agent without interrupt support (no-op loop).
+    delete (mockAgent as any).getPendingToolInterrupts;
+    delete (mockAgent as any).streamResume;
 
     statusUpdateCallback = vi.fn();
 
@@ -272,6 +276,80 @@ describe('GthAgentRunner', () => {
         const message = error instanceof Error ? error.message : String(error);
         expect(message).not.toMatch(/gcloud auth application-default login/);
       }
+    });
+  });
+
+  describe('tool-approval interrupts (run_shell_command)', () => {
+    function streamOf(...chunks: string[]) {
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (const c of chunks) yield c;
+        },
+      };
+    }
+
+    it('approves a pending tool call via the callback, then resumes with an approve decision', async () => {
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      // Initial turn streams some text, then suspends on one pending tool call.
+      mockAgent.stream.mockResolvedValue(streamOf('working'));
+      const getPending = vi
+        .fn()
+        // First check: one pending command. Second check (after resume): none.
+        .mockResolvedValueOnce([{ name: 'run_shell_command', args: { command: 'ls -la' } }])
+        .mockResolvedValueOnce([]);
+      const streamResume = vi.fn().mockResolvedValue(streamOf(' done'));
+      (mockAgent as any).getPendingToolInterrupts = getPending;
+      (mockAgent as any).streamResume = streamResume;
+
+      await runner.init(undefined, { ...mockConfig, streamOutput: true });
+      const approve = vi.fn().mockResolvedValue({ type: 'approve' });
+      runner.setToolApprovalCallback(approve);
+
+      const result = await runner.processMessages([new HumanMessage('run ls')]);
+
+      expect(approve).toHaveBeenCalledWith({
+        name: 'run_shell_command',
+        args: { command: 'ls -la' },
+      });
+      // Resume sent the HITL decisions array shape humanInTheLoopMiddleware expects.
+      expect(streamResume).toHaveBeenCalledWith(
+        { decisions: [{ type: 'approve' }] },
+        expect.anything()
+      );
+      expect(result).toBe('working done');
+    });
+
+    it('rejects when no approval callback is wired (non-interactive default)', async () => {
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      mockAgent.stream.mockResolvedValue(streamOf('working'));
+      (mockAgent as any).getPendingToolInterrupts = vi
+        .fn()
+        .mockResolvedValueOnce([{ name: 'run_shell_command', args: { command: 'rm -rf /' } }])
+        .mockResolvedValueOnce([]);
+      const streamResume = vi.fn().mockResolvedValue(streamOf(''));
+      (mockAgent as any).streamResume = streamResume;
+
+      await runner.init(undefined, { ...mockConfig, streamOutput: true });
+      // No setToolApprovalCallback → default reject.
+      mockAgent.invoke.mockResolvedValue('rejected and continued');
+
+      await runner.processMessages([new HumanMessage('run rm')]);
+
+      const resumeArg = streamResume.mock.calls[0][0];
+      expect(resumeArg.decisions[0].type).toBe('reject');
+    });
+
+    it('does not attempt interrupt resolution when the agent lacks getState support', async () => {
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      mockAgent.stream.mockResolvedValue(streamOf('hello'));
+      // No getPendingToolInterrupts / streamResume on the mock → loop no-ops.
+      delete (mockAgent as any).getPendingToolInterrupts;
+      delete (mockAgent as any).streamResume;
+
+      await runner.init(undefined, { ...mockConfig, streamOutput: true });
+      const result = await runner.processMessages([new HumanMessage('hi')]);
+
+      expect(result).toBe('hello');
     });
   });
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -489,7 +489,7 @@ export interface CustomCommandConfig {
 /**
  * Config for {@link GthDevToolkit}.
  * Tools are not applied when config is not provided.
- * Only available in `code` mode.
+ * Only available in `code`/`exec` mode (and `ask --write`).
  */
 export interface GthDevToolsConfig {
   /**
@@ -515,6 +515,45 @@ export interface GthDevToolsConfig {
    * Not applied when config is not provided.
    */
   run_single_test?: string;
+  /**
+   * Opt-in general-purpose shell tool (`run_shell_command`). Unlike the fixed
+   * `run_*` commands above, this lets the agent run ARBITRARY shell commands it
+   * composes itself — the agentic-coding escape hatch the deep agent otherwise
+   * lacks (it can read/write files but not run commands).
+   *
+   * OFF by default; only emitted when truthy. Accepts a bare boolean or an
+   * `{ enabled }` object for symmetry with future per-tool options.
+   *
+   * Because the model chooses the command, every invocation is gated behind a
+   * per-command human confirmation dialog (LangChain `humanInTheLoopMiddleware`,
+   * wired via deepagents' `interruptOn`) UNLESS {@link shellYolo} bypasses it.
+   * The confirmation — not string-filtering — is the guardrail, so the command
+   * is passed through verbatim (pipes / `$` / `;` are all legitimate).
+   *
+   * Example: `{ "shell": true }` or `{ "shell": { "enabled": true } }`.
+   */
+  shell?: boolean | { enabled?: boolean };
+  /**
+   * Opt-out of the per-command confirmation dialog for {@link shell}
+   * (`run_shell_command`) — the explicit "yolo" bypass. When `true` AND `shell`
+   * is enabled, the shell tool runs without any approval interrupt: the model's
+   * commands execute immediately. Dangerous by design; off by default.
+   *
+   * Example: `{ "shell": true, "shellYolo": true }`.
+   */
+  shellYolo?: boolean;
+}
+
+/**
+ * Normalize the {@link GthDevToolsConfig.shell} opt-in (bare boolean or `{ enabled }`)
+ * to a plain boolean. Centralized so the toolkit (tool emission) and the deep agent
+ * (interrupt wiring) agree on what "shell enabled" means.
+ */
+export function isShellToolEnabled(devTools: GthDevToolsConfig | undefined): boolean {
+  const shell = devTools?.shell;
+  if (typeof shell === 'boolean') return shell;
+  if (shell && typeof shell === 'object') return shell.enabled === true;
+  return false;
 }
 
 export interface LLMConfig extends Record<string, unknown> {

--- a/packages/core/src/core/GthAbstractAgent.ts
+++ b/packages/core/src/core/GthAbstractAgent.ts
@@ -6,6 +6,7 @@ import {
   GthCommand,
   GthCompiledGraph,
   Message,
+  PendingToolInterrupt,
   StatusLevel,
   StatusUpdateCallback,
 } from '#src/core/types.js';
@@ -129,12 +130,40 @@ export abstract class GthAbstractAgent implements GthAgentInterface {
     messages: Message[],
     runConfig: RunnableConfig
   ): Promise<IterableReadableStream<string>> {
+    debugLog('=== Starting streaming invoke ===');
+    debugLogObject('LLM Input Messages', messages);
+    return this.streamFromInput({ messages }, runConfig);
+  }
+
+  /**
+   * Resume a graph suspended on a human-in-the-loop `interrupt()` and stream the continuation
+   * as text. Identical plumbing to {@link stream} (Esc-to-interrupt, binary handling), except
+   * the graph input is a `Command({ resume })` instead of fresh `messages` — so the suspended
+   * tool-approval interrupt is answered and the run continues on the same thread.
+   */
+  async streamResume(
+    resumeValue: unknown,
+    runConfig: RunnableConfig
+  ): Promise<IterableReadableStream<string>> {
+    debugLog('=== Starting streaming resume ===');
+    debugLogObject('Resume value', resumeValue);
+    return this.streamFromInput(new Command({ resume: resumeValue }), runConfig);
+  }
+
+  /**
+   * Shared body for {@link stream} / {@link streamResume}: drive the compiled graph from
+   * `input` (fresh `{ messages }` or a resume `Command`) and surface AI text deltas as a
+   * string stream, with Esc-to-interrupt and binary-output materialization.
+   */
+  private async streamFromInput(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    input: any,
+    runConfig: RunnableConfig
+  ): Promise<IterableReadableStream<string>> {
     if (!this.agent || !this.config) {
       throw new Error('Agent not initialized. Call init() first.');
     }
 
-    debugLog('=== Starting streaming invoke ===');
-    debugLogObject('LLM Input Messages', messages);
     debugLogObject('Stream RunConfig', runConfig);
 
     this.statusUpdate(StatusLevel.INFO, '\nThinking...\n');
@@ -160,10 +189,11 @@ export abstract class GthAbstractAgent implements GthAgentInterface {
 
     let stream;
     try {
-      stream = await this.agent.stream(
-        { messages },
-        { ...runConfig, streamMode: 'messages', signal: abortController.signal }
-      );
+      stream = await this.agent.stream(input, {
+        ...runConfig,
+        streamMode: 'messages',
+        signal: abortController.signal,
+      });
     } catch (error) {
       // If stream creation fails (e.g. an auth error), the IterableReadableStream below -
       // whose finally/cancel are what normally unregister the Escape listener - is never
@@ -345,6 +375,52 @@ export abstract class GthAbstractAgent implements GthAgentInterface {
       }
       throw e;
     }
+  }
+
+  /**
+   * Inspect the checkpointed state for the thread and return the tool calls currently pending
+   * human approval (empty array when the run finished normally). A LangGraph
+   * `humanInTheLoopMiddleware` interrupt parks one `HITLRequest` per suspended super-step in
+   * `state.tasks[].interrupts[].value.actionRequests` (each `{ name, args }`); this flattens
+   * those into {@link PendingToolInterrupt}s. Defensive throughout — a graph without
+   * `getState`, or any unexpected shape, yields `[]` rather than throwing, so a missing HITL
+   * setup degrades to "no approval needed" instead of breaking the run.
+   */
+  async getPendingToolInterrupts(runConfig: RunnableConfig): Promise<PendingToolInterrupt[]> {
+    if (!this.agent || typeof this.agent.getState !== 'function') {
+      return [];
+    }
+    let state: unknown;
+    try {
+      state = await this.agent.getState(runConfig);
+    } catch (e) {
+      debugLogError('getPendingToolInterrupts getState', e);
+      return [];
+    }
+    const tasks = (state as { tasks?: unknown })?.tasks;
+    if (!Array.isArray(tasks)) {
+      return [];
+    }
+    const pending: PendingToolInterrupt[] = [];
+    for (const task of tasks) {
+      const interrupts = (task as { interrupts?: unknown })?.interrupts;
+      if (!Array.isArray(interrupts)) continue;
+      for (const interrupt of interrupts) {
+        const value = (interrupt as { value?: unknown })?.value;
+        const actionRequests = (value as { actionRequests?: unknown })?.actionRequests;
+        if (!Array.isArray(actionRequests)) continue;
+        for (const action of actionRequests) {
+          const name = (action as { name?: unknown })?.name;
+          if (typeof name !== 'string') continue;
+          const args = (action as { args?: unknown })?.args;
+          pending.push({
+            name,
+            args: args && typeof args === 'object' ? (args as Record<string, unknown>) : {},
+          });
+        }
+      }
+    }
+    return pending;
   }
 
   protected async *processEventStream(

--- a/packages/core/src/core/GthAgentRunner.ts
+++ b/packages/core/src/core/GthAgentRunner.ts
@@ -8,6 +8,8 @@ import {
   GthCommand,
   Message,
   StatusUpdateCallback,
+  ToolApprovalCallback,
+  ToolApprovalDecision,
 } from '#src/core/types.js';
 import { GthLangChainAgent } from '#src/core/GthLangChainAgent.js';
 import { enhanceVertexUnauthorizedMessage } from '#src/utils/vertexaiUtils.js';
@@ -31,6 +33,13 @@ export class GthAgentRunner {
   private config: GthConfig | null = null;
   private runConfig: RunnableConfig | null = null;
   private agentFactory: GthAgentFactory;
+  /**
+   * Consumer hook invoked when a run suspends on a tool-approval interrupt (e.g. the opt-in
+   * `run_shell_command` confirmation). Set via {@link setToolApprovalCallback}; when unset the
+   * runner REJECTS pending tool calls rather than hanging or auto-approving — the safe default
+   * for non-interactive entrypoints (a scripted `exec` run with no TTY to prompt on).
+   */
+  private toolApprovalCallback: ToolApprovalCallback | null = null;
 
   /**
    * @param agentFactory Produces the {@link GthAgentInterface} the runner drives.
@@ -47,6 +56,15 @@ export class GthAgentRunner {
     this.resolvers = resolvers;
     this.agentFactory =
       agentFactory ?? ((status, agentResolvers) => new GthLangChainAgent(status, agentResolvers));
+  }
+
+  /**
+   * Register the tool-approval handler the runner calls when a run suspends on a tool-approval
+   * interrupt (the interactive readline session wires a y/n prompt here). Pass `null` to clear.
+   * Without a handler the runner rejects pending tool calls (see {@link toolApprovalCallback}).
+   */
+  public setToolApprovalCallback(callback: ToolApprovalCallback | null): void {
+    this.toolApprovalCallback = callback;
   }
 
   /**
@@ -97,10 +115,11 @@ export class GthAgentRunner {
         const stream = await this.agent.stream(messages, this.runConfig);
         let result = '';
         try {
-          for await (const chunk of stream) {
-            debugLogObject('Stream chunk', chunk);
-            result += chunk;
-          }
+          result = await this.drainTextStream(stream);
+          // A run may suspend on one or more tool-approval interrupts (run_shell_command).
+          // Resolve them in a loop: each resume can itself suspend again on the next gated
+          // tool call, so keep going until the graph completes with no pending interrupts.
+          result += await this.resolveToolInterrupts();
         } catch (streamError) {
           // Handle streaming-specific errors
           debugLogError('Stream processing', streamError);
@@ -143,6 +162,62 @@ export class GthAgentRunner {
         error instanceof Error ? { cause: error } : undefined
       );
     }
+  }
+
+  /**
+   * Accumulate a text stream into a single string. Extracted so {@link processMessages} and
+   * the interrupt-resume loop ({@link resolveToolInterrupts}) drain streams identically.
+   */
+  private async drainTextStream(stream: AsyncIterable<string>): Promise<string> {
+    let result = '';
+    for await (const chunk of stream) {
+      debugLogObject('Stream chunk', chunk);
+      result += chunk;
+    }
+    return result;
+  }
+
+  /**
+   * After a streamed run ends, resolve any tool-approval interrupts it suspended on. For each
+   * pending tool call the {@link toolApprovalCallback} is consulted (defaulting to REJECT when
+   * no handler is wired, so a non-interactive run never hangs or auto-approves); the collected
+   * decisions are then sent back via the agent's `streamResume` as a LangChain HITL resume
+   * (`{ decisions }`). Because a resumed run can suspend again on the next gated tool call, this
+   * loops until the graph completes with no pending interrupts. Returns the concatenated text
+   * streamed across all resume turns (empty when nothing was resumed).
+   *
+   * No-ops (returns '') when the agent does not support interrupts (`getPendingToolInterrupts`/
+   * `streamResume` absent), so the lean agent and non-HITL configs are unaffected.
+   */
+  private async resolveToolInterrupts(): Promise<string> {
+    const agent = this.agent;
+    const runConfig = this.runConfig;
+    if (!agent || !runConfig) return '';
+    if (!agent.getPendingToolInterrupts || !agent.streamResume) return '';
+
+    let resumedText = '';
+    // Bound the loop defensively so a misbehaving graph that re-suspends forever cannot spin.
+    for (let guard = 0; guard < 100; guard++) {
+      const pending = await agent.getPendingToolInterrupts(runConfig);
+      if (pending.length === 0) break;
+
+      const decisions: ToolApprovalDecision[] = [];
+      for (const tool of pending) {
+        if (this.toolApprovalCallback) {
+          decisions.push(await this.toolApprovalCallback(tool));
+        } else {
+          // No interactive handler (e.g. non-TTY exec run): reject rather than auto-approve.
+          decisions.push({
+            type: 'reject',
+            message: 'Tool call rejected: no interactive approval handler available.',
+          });
+        }
+      }
+
+      const stream = await agent.streamResume({ decisions }, runConfig);
+      resumedText += await this.drainTextStream(stream);
+    }
+    return resumedText;
   }
 
   /**

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -54,7 +54,41 @@ export interface GthCompiledGraph {
   invoke(input: any, config?: RunnableConfig): Promise<{ messages: BaseMessage[] }>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   stream(input: any, config?: any): Promise<IterableReadableStream<any>>;
+  /**
+   * Read the checkpointed graph state for a thread. Present on LangGraph compiled graphs
+   * (both `createAgent` and `createDeepAgent`); used to detect a graph suspended on a
+   * human-in-the-loop `interrupt()` (its pending {@link PendingToolInterrupt} lives in
+   * `state.tasks[].interrupts[].value`). Optional because the structural surface predates it.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getState?(config: RunnableConfig): Promise<any>;
 }
+
+/**
+ * A single tool call a human-in-the-loop interrupt is waiting on, surfaced from the
+ * suspended graph state so a consumer (the interactive session) can render an approve/reject
+ * prompt. Mirrors LangChain's HITL `ActionRequest` (tool name + the args it would run with).
+ */
+export interface PendingToolInterrupt {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * A consumer-supplied decision on a {@link PendingToolInterrupt}: approve runs the tool,
+ * reject feeds the model a tool-rejected message (with the optional reason).
+ */
+export type ToolApprovalDecision = { type: 'approve' } | { type: 'reject'; message?: string };
+
+/**
+ * Callback the {@link GthAgentRunner} invokes when a run suspends on a tool-approval
+ * interrupt, once per pending tool call. Returns the human's decision. When no handler is
+ * wired (e.g. a non-interactive run), the runner defaults to reject so a run can never
+ * silently hang or auto-approve.
+ */
+export type ToolApprovalCallback = (
+  pending: PendingToolInterrupt
+) => Promise<ToolApprovalDecision> | ToolApprovalDecision;
 
 export interface GthAgentInterface {
   init(
@@ -86,6 +120,24 @@ export interface GthAgentInterface {
     queuedMessages?: BaseMessage[],
     signal?: AbortSignal
   ): AsyncGenerator<AgentStreamEvent>;
+
+  /**
+   * Resume a graph suspended on a human-in-the-loop `interrupt()` and stream the continuation
+   * as text (the string counterpart to {@link streamWithEventsResume}, for the readline path).
+   * Optional: only implemented by agents that support tool-approval interrupts.
+   */
+  streamResume?(
+    resumeValue: unknown,
+    runConfig: RunnableConfig
+  ): Promise<IterableReadableStream<string>>;
+
+  /**
+   * Inspect the checkpointed state for the thread and return any tool calls currently pending
+   * human approval (empty when the run completed normally). Optional: only implemented by
+   * agents whose graph exposes `getState`. Used by {@link GthAgentRunner} to drive the
+   * approve/reject confirmation loop.
+   */
+  getPendingToolInterrupts?(runConfig: RunnableConfig): Promise<PendingToolInterrupt[]>;
 
   cleanup?(): Promise<void>;
 }


### PR DESCRIPTION
Give the code-mode deep agent a real shell tool, off by default, behind a per-command human-in-the-loop confirmation dialog with an opt-in yolo bypass. Implements [EXT-9].

## What it does

Off by default. Enabled per-command under `commands.{code,exec,ask}.devTools`:

```jsonc
{
  "commands": {
    "code": {
      "devTools": {
        "run_tests": "pnpm test",   // existing fixed commands still work
        "shell": true,              // enable run_shell_command (also accepts { "enabled": true })
        "shellYolo": false          // optional: true = run WITHOUT confirmation
      }
    }
  }
}
```

- `shell` off → tool not emitted.
- `shell` on, `shellYolo` off → tool emitted; `createDeepAgent` gets `interruptOn = { run_shell_command: { allowedDecisions: ['approve','reject'] } }`. Each call suspends the graph; the readline interactive session prompts `Run this command? (y/N):`. Anything but `y`/`yes` rejects (fail-closed) and the model receives a tool-rejected message and continues.
- `shell` on, `shellYolo` on → tool emitted, `interruptOn` left undefined (commands run unconfirmed); a loud WARNING is logged.
- Non-interactive / no approval handler wired → the runner **rejects** pending tool calls rather than hanging or auto-approving.

The command is passed to `spawn(command, { shell: true })` verbatim — the path sanitizer is deliberately NOT applied (a real shell command legitimately contains pipes / `$` / `;`); the confirmation is the guardrail. Tool name avoids deepagents' reserved `execute`.

## Files changed

- `packages/core/src/config.ts` — `GthDevToolsConfig.shell`/`shellYolo` + `isShellToolEnabled()`.
- `packages/agent/src/tools/GthDevToolkit.ts` — emits `run_shell_command`.
- `packages/agent/src/core/GthDeepAgent.ts` — `interruptOn` on params + wiring into `createDeepAgent`.
- `packages/core/src/core/types.ts` — `PendingToolInterrupt`, `ToolApprovalDecision`, `ToolApprovalCallback`; optional `getState`/`streamResume`/`getPendingToolInterrupts`.
- `packages/core/src/core/GthAbstractAgent.ts` — `streamResume()` + `getPendingToolInterrupts()`.
- `packages/core/src/core/GthAgentRunner.ts` — `setToolApprovalCallback()` + interrupt-resolve loop.
- `packages/agent/src/modules/interactiveSessionModule.ts` — readline y/N confirm handler.
- Tests: `GthDevToolkit.simple.spec.ts`, `GthDeepAgent.spec.ts`, `GthAgentRunner.spec.ts`, `codeCommand.spec.ts`.

## Verification

- `pnpm run build` → green (Node ≥24 engine WARN only; tested on Node 22).
- `pnpm run test` → **834/834 pass** (67 test files).

## Follow-ups (not in this PR)

1. **Ink TUI path** (`tuiSessionModule.tsx`) does not surface the confirmation prompt yet — only the readline interactive session does. In a TUI session a `run_shell_command` call suspends with no prompt (no auto-approve, no hang, but no way to approve from the TUI). Wiring `getPendingToolInterrupts` + an Ink approve/reject affordance + `streamResume` is the remaining work.
2. Manual smoke test with a live model (approve + reject paths end-to-end).
3. EXT-10 (LLM-as-judge command vetting) builds on this `interruptOn` seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UH8RjaD7KvV1Ao6G9MWQVD)_