### PR TITLE
REL-2: 2.x address sweep + 2.0.0-alpha.3 + gaunt-sloth --acp-agent

### DIFF
--- a/.aiignore
+++ b/.aiignore
@@ -12,7 +12,7 @@
 /docs-generated
 .junie
 .idea
-gaunt-sloth-assistant.iml
+*.iml
 .gsloth/.gsloth-settings/jira/
 .gsloth/gth_*
 /gaunt-sloth.log

--- a/.github/workflows/_review-shared.yml
+++ b/.github/workflows/_review-shared.yml
@@ -6,7 +6,7 @@
 #
 # The pull_request_target context runs files from `main`, not from the PR.
 # This is important to avoid executing code from the PR.
-# See postmortem here https://github.com/Galvanized-Pukeko/gaunt-sloth-assistant/discussions/304
+# See postmortem here https://github.com/pukeko-robotics/gaunt-sloth/discussions/304
 name: AI PR Review (shared)
 
 on:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -2,7 +2,7 @@ name: AI PR Review
 
 # The pull_request_target is an important feature. It is running on files from `main`.
 # This is important to avoid changes which would execute code from the PR.
-# See postmortem here https://github.com/Galvanized-Pukeko/gaunt-sloth-assistant/discussions/304
+# See postmortem here https://github.com/pukeko-robotics/gaunt-sloth/discussions/304
 #
 # Flow:
 #   concierge       - classifies the PR author (internal vs external).

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 .junie
 .idea
 .claude/settings.local.json
-gaunt-sloth-assistant.iml
+*.iml
 .gsloth/.gsloth-settings/jira/
 .gsloth/gth_*
 /gaunt-sloth.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,11 @@ pnpm run format
 
 ## Local Development Registry (optional)
 
-The four publishable packages — `@gaunt-sloth/{core,tools,api,review}` — release
-in lock-step (`packages/core/package.json` holds the authoritative version).
+The publishable packages — the `@gaunt-sloth/{agent,core,review}` libraries plus
+the `gaunt-sloth` CLI app (dir `packages/app`) — release in lock-step
+(`packages/core/package.json` holds the authoritative version).
 When iterating against downstream
-consumers (`galvanized-pukeko-ai-ui`, `pukeko-robot-controller`, etc.), it is
+consumers (`galvanized-pukeko`, `pukeko-robot-controller`, etc.), it is
 much faster to publish dev versions to a local [Verdaccio](https://verdaccio.org)
 registry than to rebuild tarballs each cycle.
 
@@ -116,14 +117,14 @@ pnpm run release:bump 0.0.7   # passing the current version re-syncs without bum
 pnpm run release:bump-and-commit
 
 pnpm run build
-pnpm run release:publish    # publishes core → tools → api → review to Verdaccio
+pnpm run release:publish    # publishes core → agent → review → app to Verdaccio
 ```
 
-`release:bump` writes the new version into `packages/{tools,core,api,review}`,
+`release:bump` writes the new version into `packages/{core,agent,review}`,
 pins their internal `@gaunt-sloth/*` deps to that exact version (no caret —
 the lock-stepped set has no useful range semantics), and rewrites
-`packages/app`'s `@gaunt-sloth/*` pins to match without touching
-assistant's own version (1.5.x is its independent user-facing semver).
+`packages/app`'s `@gaunt-sloth/*` pins to match. On the 2.x line the
+`gaunt-sloth` app is versioned in lock-step with the libraries.
 
 Then in any downstream repo, bump its `@gaunt-sloth/*` pins to the new version
 and run `pnpm install` — Verdaccio serves the local copy via the per-repo
@@ -225,13 +226,13 @@ Open a GitHub Issue describing:
 
 ## Documentation Publishing
 
-If you need to publish project documentation, clone `gaunt-sloth-assistant.github.io` in the same parent directory as this repository and run:
+API documentation is generated from the TypeScript sources with TypeDoc:
 
 ```bash
-./update-docs.sh
+npm run typedoc
 ```
 
-Commit and push from the `gaunt-sloth-assistant.github.io` repository.
+The generated output is published through the [gauntsloth.app](https://gauntsloth.app/) site (docs at https://gauntsloth.app/docs/).
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Gaunt Sloth Assistant
-[![Tests and Lint](https://github.com/Galvanized-Pukeko/gaunt-sloth-assistant/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/Galvanized-Pukeko/gaunt-sloth-assistant/actions/workflows/unit-tests.yml) [![Integration Tests](https://github.com/Galvanized-Pukeko/gaunt-sloth-assistant/actions/workflows/integration-tests.yml/badge.svg?event=push)](https://github.com/Galvanized-Pukeko/gaunt-sloth-assistant/actions/workflows/integration-tests.yml)
+# Gaunt Sloth
+[![Tests and Lint](https://github.com/pukeko-robotics/gaunt-sloth/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/pukeko-robotics/gaunt-sloth/actions/workflows/unit-tests.yml) [![Integration Tests](https://github.com/pukeko-robotics/gaunt-sloth/actions/workflows/integration-tests.yml/badge.svg?event=push)](https://github.com/pukeko-robotics/gaunt-sloth/actions/workflows/integration-tests.yml)
 
-Gaunt Sloth Assistant is a command-line AI assistant for CI/CD workflows, code reviews, and DIY projects. It supports PR and diff reviews with requirements context, code and diff Q&A, interactive chat and coding sessions, and controlled automation through predefined tools and JSON or JavaScript configuration.
+Gaunt Sloth is a command-line AI assistant for CI/CD workflows, code reviews, and DIY projects. It supports PR and diff reviews with requirements context, code and diff Q&A, interactive chat and coding sessions, and controlled automation through predefined tools and JSON or JavaScript configuration.
 
 ![GSloth Banner](assets/gaunt-sloth-logo.png)
 
 Based on [LangChain.js](https://github.com/langchain-ai/langchainjs)
 
-[Documentation](https://gaunt-sloth-assistant.github.io/docs/) | [Official Site](https://gaunt-sloth-assistant.github.io/) | [NPM](https://www.npmjs.com/package/gaunt-sloth-assistant) | [GitHub](https://github.com/Galvanized-Pukeko/gaunt-sloth-assistant)
+[Documentation](https://gauntsloth.app/docs/) | [Official Site](https://gauntsloth.app/) | [NPM](https://www.npmjs.com/package/gaunt-sloth) | [GitHub](https://github.com/pukeko-robotics/gaunt-sloth)
 
 ## Why?
 
@@ -31,19 +31,18 @@ The promise of Gaunt Sloth:
 
 This repository is an NPM workspace monorepo. The dependency chain is:
 
-`@gaunt-sloth/core` <- `@gaunt-sloth/tools` <- `@gaunt-sloth/api` <- `gaunt-sloth-assistant`
+`@gaunt-sloth/core` <- `@gaunt-sloth/agent` <- `gaunt-sloth`
 
-`@gaunt-sloth/review` depends only on `@gaunt-sloth/core` (with `@gaunt-sloth/tools` as an optional peer).
+`@gaunt-sloth/review` depends only on `@gaunt-sloth/core`, and the `gaunt-sloth` app depends on all three libraries (`@gaunt-sloth/agent`, `@gaunt-sloth/core`, `@gaunt-sloth/review`).
 
 | Package | Description |
 |---|---|
-| `gaunt-sloth-assistant` | Main CLI application. Installs the `gsloth`/`gth` binaries. Most users only need this package. |
-| `@gaunt-sloth/api` | AG-UI server, A2A client, MCP utilities, and tool resolvers. Includes the `gaunt-sloth-api` binary. |
-| `@gaunt-sloth/review` | Review and Q&A modules with content providers (GitHub, Jira). Includes the `gaunt-sloth-review` binary for lightweight CI pipelines. |
-| `@gaunt-sloth/tools` | Filesystem toolkit, custom tools, dev tools, and middleware registry. |
-| `@gaunt-sloth/core` | Config system, agent infrastructure, LLM provider wrappers, and shared utilities. |
+| `gaunt-sloth` | Main CLI application (`packages/app`). Installs the `gsloth`/`gth` binaries. Most users only need this package. |
+| `@gaunt-sloth/agent` | Agent runtime (`packages/agent`): AG-UI server, A2A client, MCP utilities, filesystem and custom tools, and middleware registry — bundles the former tools and api packages. |
+| `@gaunt-sloth/review` | Review and Q&A modules (`packages/review`) with content providers (GitHub, Jira). Includes the `gaunt-sloth-review` binary for lightweight CI pipelines. |
+| `@gaunt-sloth/core` | Config system, agent infrastructure, LLM provider wrappers, and shared utilities (`packages/core`). |
 
-Most users install `gaunt-sloth-assistant` globally and do not interact with the sub-packages directly. `@gaunt-sloth/review` can be used standalone in CI pipelines — it has no dependency on `commander`, MCP, or A2A, making it a lighter option when only review functionality is needed.
+Most users install `gaunt-sloth` globally and do not interact with the sub-packages directly. `@gaunt-sloth/review` can be used standalone in CI pipelines — it has no dependency on `commander`, MCP, or A2A, making it a lighter option when only review functionality is needed.
 
 ## What GSloth does
 
@@ -82,7 +81,7 @@ Unlike autonomous coding agents or hosted review services, GSloth is a **configu
 - Anthropic;
 - OpenAI (and other providers using OpenAI format, such as Inception);
 - Local AI: LM Studio, Ollama, llama.cpp (Via OpenAI compatibitlity)
-- Ollama with JS config (some of the models, see https://github.com/Galvanized-Pukeko/gaunt-sloth-assistant/discussions/107)
+- Ollama with JS config (some of the models, see https://github.com/pukeko-robotics/gaunt-sloth/discussions/107)
 - xAI;
 
 `*` Any other provider supported by LangChain.JS should also work with [JS config](./docs/CONFIGURATION.md#javascript-configuration).
@@ -180,7 +179,7 @@ Tested with Node 22 LTS.
 
 ### NPM
 ```bash
-npm install gaunt-sloth-assistant -g
+npm install gaunt-sloth -g
 ```
 
 ## Configuration
@@ -329,7 +328,7 @@ Make sure you either define `XAI_API_KEY` environment variable or edit your conf
 
 ### Other AI providers
 Any other AI provider supported by Langchain.js can be configured with js [Config](./docs/CONFIGURATION.md).
-For example, Ollama can be set up with JS config (some of the models, see https://github.com/Galvanized-Pukeko/gaunt-sloth-assistant/discussions/107)
+For example, Ollama can be set up with JS config (some of the models, see https://github.com/pukeko-robotics/gaunt-sloth/discussions/107)
 
 ### JavaScript Configuration with Custom Middleware and Tools
 JavaScript configs enable advanced customization including custom middleware and tools that aren't available in JSON configs. See the [JavaScript config example](./examples/js-config/README.md) for a complete demonstration of creating custom logging middleware and custom tools.
@@ -358,7 +357,7 @@ Gaunt Sloth supports the [A2A protocol](https://a2a-protocol.org/) for connectin
 ## Uninstall
 Uninstall global NPM package:
 ```bash
-npm uninstall -g gaunt-sloth-assistant
+npm uninstall -g gaunt-sloth
 ```
 
 Remove global config (if any)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2,7 +2,7 @@
 
 Populate `.gsloth.guidelines.md` with your project details and quality requirements.
 A proper preamble is paramount for good inference.
-Check [.gsloth.guidelines.md](https://github.com/Galvanized-Pukeko/gaunt-sloth-assistant/blob/main/.gsloth.guidelines.md) for example.
+Check [.gsloth.guidelines.md](https://github.com/pukeko-robotics/gaunt-sloth/blob/main/.gsloth.guidelines.md) for example.
 
 Your project should have the following files in order for gsloth to function:
 
@@ -249,9 +249,9 @@ By default, Gaunt Sloth falls back to its bundled `.gsloth.*.md` prompt files wh
 
 ## Configuration Object
 
-Refer to documentation site for [Configuration Interface](https://gaunt-sloth-assistant.github.io/docs/interfaces/config.GthConfig.html)
+Refer to documentation site for [Configuration Interface](https://gauntsloth.app/docs/interfaces/config.GthConfig.html)
 
-Refer to documentation site for [Default Config Values](https://gaunt-sloth-assistant.github.io/docs/variables/config.DEFAULT_CONFIG.html)
+Refer to documentation site for [Default Config Values](https://gauntsloth.app/docs/variables/config.DEFAULT_CONFIG.html)
 
 It is always worth checking sourcecode in [config.ts](../src/config.ts) for more insightful information.
 

--- a/docs/TEST-DEPLOY.md
+++ b/docs/TEST-DEPLOY.md
@@ -2,7 +2,7 @@
 
 Scripts for testing `@gaunt-sloth/review` as a standalone global install,
 without workspace hoisting leaking in transitive dependencies from other packages
-(e.g. `gaunt-sloth-assistant`).
+(e.g. `gaunt-sloth`).
 
 ## Bumping versions before deploy
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Galvanized-Pukeko/gaunt-sloth.git"
+    "url": "git+https://github.com/pukeko-robotics/gaunt-sloth.git"
   },
   "engines": {
     "node": ">=24.0.0",

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -8,9 +8,18 @@ The deep-agent runtime for Gaunt Sloth. Consolidates what were previously
 - MCP client + OAuth provider
 - A2A client and tools
 - The AG-UI server (`startAgUiServer`) and interactive session module
+- The ACP (Agent Client Protocol) server (`startAcpServer`), exposed as the
+  `gaunt-sloth-acp` binary
 - The `createResolvers` tool/middleware resolver wiring
 
 It builds on `@gaunt-sloth/core` (config, provider factory, lean langchain runtime).
+
+> **Running the ACP server:** prefer `gaunt-sloth --acp-agent` from the
+> [`gaunt-sloth`](../app) app, not the standalone `gaunt-sloth-acp` binary. The LLM
+> providers are `peerDependencies` of `@gaunt-sloth/core` that only the app declares, so a
+> bare `@gaunt-sloth/agent` install has no providers to construct a model from. See the
+> [app README → ACP server](../app/README.md#acp-server-editor-integration) for setup and a
+> Zed `settings.json` example.
 
 > `@gaunt-sloth/tools` and `@gaunt-sloth/api` are deprecated and now re-export
 > from this package.

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaunt-sloth/agent",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Deep agent runtime for Gaunt Sloth: tools, middleware, MCP/A2A clients and the AG-UI server",
   "license": "MIT",
   "author": "Andrew Kondratev",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -6,13 +6,13 @@
   "author": "Andrew Kondratev",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Galvanized-Pukeko/gaunt-sloth.git",
+    "url": "git+https://github.com/pukeko-robotics/gaunt-sloth.git",
     "directory": "packages/agent"
   },
   "bugs": {
-    "url": "https://github.com/Galvanized-Pukeko/gaunt-sloth/issues"
+    "url": "https://github.com/pukeko-robotics/gaunt-sloth/issues"
   },
-  "homepage": "https://github.com/Galvanized-Pukeko/gaunt-sloth/tree/main/packages/agent#readme",
+  "homepage": "https://github.com/pukeko-robotics/gaunt-sloth/tree/main/packages/agent#readme",
   "keywords": [
     "ai",
     "agent",

--- a/packages/agent/src/mcp/OAuthClientProviderImpl.ts
+++ b/packages/agent/src/mcp/OAuthClientProviderImpl.ts
@@ -111,7 +111,7 @@ export class OAuthClientProviderImpl implements OAuthClientProvider {
     return {
       redirect_uris: [this.config.redirectUrl],
       client_name: 'Gaunt Sloth Assistant',
-      client_uri: 'https://gaunt-sloth-assistant.github.io/',
+      client_uri: 'https://gauntsloth.app/',
       software_id: '1dd38b83-946b-4631-8855-66ee467bfd68',
       scope: 'mcp:read mcp:write',
       token_endpoint_auth_method: 'none',

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -41,6 +41,54 @@ npm install -g gaunt-sloth
 
 For full usage documentation see the [root README](../../README.md) and [docs/COMMANDS.md](../../docs/COMMANDS.md).
 
+## ACP server (editor integration)
+
+Gaunt Sloth can run as an [Agent Client Protocol](https://agentclientprotocol.com/) (ACP)
+server, so an ACP host — Zed, JetBrains, a future Pukeko client — can spawn it as a coding
+agent. It speaks ACP JSON-RPC over **stdio** (no port, no flags beyond the switch below); the
+host launches it as a subprocess.
+
+Run it through this package:
+
+```bash
+npm install -g gaunt-sloth@alpha
+gaunt-sloth --acp-agent
+```
+
+**Install the app (`gaunt-sloth`), not `@gaunt-sloth/agent`.** The agent package also ships a
+standalone `gaunt-sloth-acp` binary, but the LLM providers (`@langchain/anthropic`, `openai`,
+`google`, …) are `peerDependencies` of `@gaunt-sloth/core` that **only this app package
+declares as real dependencies**. A bare `@gaunt-sloth/agent` install leaves those peers unmet,
+so its ACP server has no provider to build a model from. `gaunt-sloth --acp-agent` runs the
+exact same ACP server but resolves providers out of the app's dependency tree, so every
+configured provider works. (`stdout` is the protocol channel and is kept clean — gsloth's
+status/config output is redirected to `stderr`.)
+
+Provider credentials and model selection come from your usual gsloth config
+(`.gsloth.config.*` / env vars such as `ANTHROPIC_API_KEY`); the ACP server reads them via the
+same `initConfig` path as the CLI. Run the host from your project directory (or set its `cwd`)
+so config and the per-session workspace resolve correctly.
+
+### Zed
+
+Add to Zed `settings.json`:
+
+```json
+{
+  "agent_servers": {
+    "Gaunt Sloth": {
+      "command": "gaunt-sloth",
+      "args": ["--acp-agent"],
+      "env": {}
+    }
+  }
+}
+```
+
+Point `command` at the global `gaunt-sloth` binary (after `npm install -g gaunt-sloth@alpha`),
+or at an absolute path to `cli.js` for a local build. Other ACP hosts (JetBrains, etc.) take
+the same `command` + `args` pair.
+
 ## Related packages
 
 - [`@gaunt-sloth/core`](../core) — Core utilities, config, and agent infrastructure

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -71,12 +71,13 @@ so config and the per-session workspace resolve correctly.
 
 ### Zed
 
-Add to Zed `settings.json`:
+Add to Zed `settings.json` (or Settings -> External Agents -> Add Agent -> Custom Agent):
 
 ```json
 {
   "agent_servers": {
     "Gaunt Sloth": {
+      "type": "custom",
       "command": "gaunt-sloth",
       "args": ["--acp-agent"],
       "env": {}

--- a/packages/app/cli.js
+++ b/packages/app/cli.js
@@ -9,15 +9,48 @@ process.on('warning', (warning) => {
   console.warn(warning);
 });
 
-// This is a minimalistic entry point that sets the installDir in systemUtils
-// and delegates to the compiled TypeScript code in dist/cli.js
-import { setEntryPoint } from './dist/utils/systemUtils.js';
+// --- ACP server bypass -----------------------------------------------------
+// `gaunt-sloth --acp-agent` runs the Agent Client Protocol (ACP) server instead
+// of the normal CLI, so an ACP host (Zed, JetBrains, a future Pukeko client) can
+// spawn the fat `gaunt-sloth` package as a coding-agent subprocess.
+//
+// Why route ACP through the app rather than the standalone `gaunt-sloth-acp`
+// binary in @gaunt-sloth/agent: the LLM providers (@langchain/anthropic, openai,
+// google, …) are peerDependencies of @gaunt-sloth/core, and only this app package
+// declares them as real dependencies. A bare `@gaunt-sloth/agent` install leaves
+// those peers unmet, so its ACP server has no providers to construct a model from.
+// Starting the same ACP server from here resolves providers out of the app's tree.
+//
+// ACP speaks JSON-RPC over stdio, so stdout MUST stay a clean protocol channel:
+// redirect console.log/info (used by initConfig/status output) to stderr BEFORE
+// touching config, exactly as the standalone `gaunt-sloth-acp` entry does.
+if (process.argv.includes('--acp-agent')) {
+  for (const method of ['log', 'info']) {
+    console[method] = (...args) => process.stderr.write(args.join(' ') + '\n');
+  }
+  const [{ initConfig }, { displayError }, { startAcpServer }] = await Promise.all([
+    import('@gaunt-sloth/core/config.js'),
+    import('@gaunt-sloth/core/utils/consoleUtils.js'),
+    import('@gaunt-sloth/agent'),
+  ]);
+  try {
+    const config = await initConfig({});
+    await startAcpServer(config);
+  } catch (err) {
+    displayError(`ACP server failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+} else {
+  // This is a minimalistic entry point that sets the installDir in systemUtils
+  // and delegates to the compiled TypeScript code in dist/cli.js
+  const { setEntryPoint } = await import('./dist/utils/systemUtils.js');
 
-// Set the installation directory in systemUtils
-setEntryPoint(import.meta.url);
+  // Set the installation directory in systemUtils
+  setEntryPoint(import.meta.url);
 
-// Import and run the compiled TypeScript code
-import('./dist/cli.js').catch((err) => {
-  console.error('Failed to load application:', err);
-  process.exit(1);
-});
+  // Import and run the compiled TypeScript code
+  import('./dist/cli.js').catch((err) => {
+    console.error('Failed to load application:', err);
+    process.exit(1);
+  });
+}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaunt-sloth",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "",
   "license": "MIT",
   "author": "Andrew Kondratev",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -8,13 +8,13 @@
   "main": "dist/cli.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Galvanized-Pukeko/gaunt-sloth.git",
+    "url": "git+https://github.com/pukeko-robotics/gaunt-sloth.git",
     "directory": "packages/app"
   },
   "bugs": {
-    "url": "https://github.com/Galvanized-Pukeko/gaunt-sloth/issues"
+    "url": "https://github.com/pukeko-robotics/gaunt-sloth/issues"
   },
-  "homepage": "https://github.com/Galvanized-Pukeko/gaunt-sloth#readme",
+  "homepage": "https://github.com/pukeko-robotics/gaunt-sloth#readme",
   "keywords": [
     "ai",
     "agent",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -11,7 +11,7 @@ Core utilities and types for Gaunt Sloth.
 - State and artifact storage: `artifactStore`
 - Shared constants and types
 
-AI vendor packages are not direct dependencies. Each vendor package is an optional peer dependency, resolved at runtime by whichever consumer (e.g. `gaunt-sloth-assistant`) pulls them in.
+AI vendor packages are not direct dependencies. Each vendor package is an optional peer dependency, resolved at runtime by whichever consumer (e.g. `gaunt-sloth`) pulls them in.
 
 ## Dependencies
 
@@ -29,7 +29,6 @@ import { display } from '@gaunt-sloth/core/utils/consoleUtils.js';
 ## Related packages
 
 - [`@gaunt-sloth/core`](../core) — Core utilities, config, and agent infrastructure (this package)
-- [`@gaunt-sloth/tools`](../tools) — Built-in tools, filesystem toolkit, and middleware registry
-- [`@gaunt-sloth/api`](../api) — API server, AG-UI, MCP, and A2A integration
+- [`@gaunt-sloth/agent`](../agent) — Agent runtime: built-in tools, filesystem toolkit, middleware registry, API server, AG-UI, MCP, and A2A integration
 - [`@gaunt-sloth/review`](../review) — Review and Q&A modules with standalone CLI
-- [`gaunt-sloth-assistant`](../assistant) — Main CLI application
+- [`gaunt-sloth`](../app) — Main CLI application

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,13 +6,13 @@
   "author": "Andrew Kondratev",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Galvanized-Pukeko/gaunt-sloth.git",
+    "url": "git+https://github.com/pukeko-robotics/gaunt-sloth.git",
     "directory": "packages/core"
   },
   "bugs": {
-    "url": "https://github.com/Galvanized-Pukeko/gaunt-sloth/issues"
+    "url": "https://github.com/pukeko-robotics/gaunt-sloth/issues"
   },
-  "homepage": "https://github.com/Galvanized-Pukeko/gaunt-sloth/tree/main/packages/core#readme",
+  "homepage": "https://github.com/pukeko-robotics/gaunt-sloth/tree/main/packages/core#readme",
   "keywords": [
     "ai",
     "agent",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaunt-sloth/core",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Core utilities and types for Gaunt Sloth",
   "license": "MIT",
   "author": "Andrew Kondratev",

--- a/packages/core/src/providers/openrouter.ts
+++ b/packages/core/src/providers/openrouter.ts
@@ -30,7 +30,7 @@ export async function processJsonConfig(
       baseURL: 'https://openrouter.ai/api/v1',
       ...(llmConfig.configuration || {}),
       defaultHeaders: {
-        'HTTP-Referer': 'https://gaunt-sloth-assistant.github.io/',
+        'HTTP-Referer': 'https://gauntsloth.app/',
         'X-Title': 'Gaunt Sloth Assistant',
       },
     },

--- a/packages/review/README.md
+++ b/packages/review/README.md
@@ -58,7 +58,6 @@ LLM provider than local development.
 ## Dependencies
 
 - `@gaunt-sloth/core` (required)
-- `@gaunt-sloth/tools` (optional peer dependency)
 
 No MCP, no A2A, no commander. This is intentional to keep the package lightweight for CI use.
 
@@ -73,7 +72,6 @@ import { commandUtils } from '@gaunt-sloth/review/commandUtils.js';
 ## Related packages
 
 - [`@gaunt-sloth/core`](../core) — Core utilities, config, and agent infrastructure
-- [`@gaunt-sloth/tools`](../tools) — Built-in tools, filesystem toolkit, and middleware registry
-- [`@gaunt-sloth/api`](../api) — API server, AG-UI, MCP, and A2A integration
+- [`@gaunt-sloth/agent`](../agent) — Agent runtime: built-in tools, filesystem toolkit, middleware registry, API server, AG-UI, MCP, and A2A integration
 - [`@gaunt-sloth/review`](../review) — Review and Q&A modules with standalone CLI (this package)
-- [`gaunt-sloth-assistant`](../assistant) — Main CLI application
+- [`gaunt-sloth`](../app) — Main CLI application

--- a/packages/review/package.json
+++ b/packages/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaunt-sloth/review",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "Review functionality for Gaunt Sloth",
   "license": "MIT",
   "author": "Andrew Kondratev",

--- a/packages/review/package.json
+++ b/packages/review/package.json
@@ -6,13 +6,13 @@
   "author": "Andrew Kondratev",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Galvanized-Pukeko/gaunt-sloth.git",
+    "url": "git+https://github.com/pukeko-robotics/gaunt-sloth.git",
     "directory": "packages/review"
   },
   "bugs": {
-    "url": "https://github.com/Galvanized-Pukeko/gaunt-sloth/issues"
+    "url": "https://github.com/pukeko-robotics/gaunt-sloth/issues"
   },
-  "homepage": "https://github.com/Galvanized-Pukeko/gaunt-sloth/tree/main/packages/review#readme",
+  "homepage": "https://github.com/pukeko-robotics/gaunt-sloth/tree/main/packages/review#readme",
   "keywords": [
     "ai",
     "agent",

--- a/typedoc.json
+++ b/typedoc.json
@@ -9,7 +9,7 @@
   "sourceLinkExternal": true,
   "includeVersion": false,
   "navigationLinks": {
-    "GitHub": "https://github.com/Galvanized-Pukeko/gaunt-sloth"
+    "GitHub": "https://github.com/pukeko-robotics/gaunt-sloth"
   },
   "highlightLanguages": ["typescript", "javascript", "markdown", "json", "bash"],
   "markdownItOptions": {

--- a/update-docs.sh
+++ b/update-docs.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-VERSION=$(node -p "require('./packages/app/package.json').version")
-npx typedoc --name "Gaunt Sloth Assistant - v${VERSION}"
-rm -r ../gaunt-sloth-assistant.github.io/docs
-cp -r docs-generated ../gaunt-sloth-assistant.github.io/docs


### PR DESCRIPTION
2.x alpha prep (REL-2). Four commits:

1. **address sweep** — package.json metadata `Galvanized-Pukeko` → `pukeko-robotics`; README/docs links → `gauntsloth.app` + `gaunt-sloth` npm pkg; README dep-chain/table rewritten to the v2 package set (`@gaunt-sloth/agent` bundles former tools+api); code URLs (OAuth `client_uri`, OpenRouter `HTTP-Referer`) → `https://gauntsloth.app/`; workflow comments; `typedoc.json`; `*.iml`; deleted `update-docs.sh` + reworked CONTRIBUTING; core/review README footer `../assistant` → `../app`; root README H1 → "Gaunt Sloth". Kept the `gaunt-sloth-assistant` bin alias, historical release-notes, spec fixtures.
2. **bump** `2.0.0-alpha.2` → `2.0.0-alpha.3` (all four lock-stepped via `bump.mjs`, `publishConfig.tag = alpha`).
3. **feat: `gaunt-sloth --acp-agent`** — routes the ACP server through the fat app so an ACP host (Zed/JetBrains) gets a working agent. The standalone `@gaunt-sloth/agent` `gaunt-sloth-acp` bin leaves the provider peerDependencies (declared on `@gaunt-sloth/core`, satisfied only by the app) unmet; the app bypass reuses the same `startAcpServer` but resolves providers from the app tree. `cli.js` intercepts the flag before commander and redirects `console.log/info` → stderr to keep stdout a clean JSON-RPC channel. Documented in app + agent READMEs with a Zed `settings.json` example.
4. **docs** — clarify Zed ACP config.

Verified: 1000 tests + build + lint green; ACP `initialize` returns a clean JSON-RPC response on stdout with status on stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)