### PR TITLE
ci: fix post-release bump (pnpm lockfile) + add isolated bump-test wo…

### DIFF
--- a/.github/workflows/bump-test.yml
+++ b/.github/workflows/bump-test.yml
@@ -1,0 +1,123 @@
+name: Bump test (isolated)
+
+# Throwaway harness to iterate on the POST-RELEASE BUMP in isolation, without
+# tagging, creating a GitHub Release, or publishing to npm.
+#
+# Why this exists: in release.yml the ship steps (tag / GitHub Release / npm
+# publish) are irreversible, but the LAST thing the `release` job does —
+# `release:bump-and-commit` (bump.mjs --commit) then push main — has repeatedly
+# been where the run dies. This workflow runs ONLY that bump+push portion so it
+# can be re-dispatched freely until green, then folded back into release.yml.
+#
+# SAFE BY DEFAULT: it checks out main, runs the bump, and prints the resulting
+# diff/status — but does NOT push anywhere unless you opt in. When `do_push` is
+# true it force-pushes the bump commit to a DISPOSABLE branch (`push_branch`,
+# default `ci/bump-test`), never to main, so main is never touched here.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Bump verb to test (mirrors release.yml). Not a real release.'
+        type: choice
+        required: true
+        default: prerelease
+        options:
+          - patch
+          - minor
+          - major
+          - prepatch
+          - preminor
+          - premajor
+          - prerelease
+          - explicit
+      preid:
+        description: 'Prerelease channel — only used by the pre*/prerelease verbs'
+        type: choice
+        required: false
+        default: alpha
+        options:
+          - alpha
+          - beta
+          - rc
+      explicit_version:
+        description: 'Exact version — only used when bump = explicit'
+        type: string
+        required: false
+        default: ''
+      do_push:
+        description: 'Also push the bump commit to a disposable test branch (never main)'
+        type: boolean
+        required: false
+        default: false
+      push_branch:
+        description: 'Disposable branch to force-push to when do_push is true'
+        type: string
+        required: false
+        default: ci/bump-test
+
+jobs:
+  bump-test:
+    name: Run bump.mjs in isolation (no tag / release / publish)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # only to force-push the disposable test branch when do_push=true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          # full history so the bump commit sits on top of real main, matching release.yml
+          fetch-depth: 0
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Show version BEFORE bump
+        run: node -p "'before: ' + require('./packages/core/package.json').version"
+      - name: Run bump-and-commit (the step under test)
+        env:
+          BUMP: ${{ inputs.bump }}
+          PREID: ${{ inputs.preid }}
+          EXPLICIT_VERSION: ${{ inputs.explicit_version }}
+        run: |
+          set -euo pipefail
+          if [ "$BUMP" = "explicit" ]; then
+            if [ -z "$EXPLICIT_VERSION" ]; then
+              echo "::error::bump=explicit requires explicit_version" >&2
+              exit 1
+            fi
+            pnpm run release:bump-and-commit -- "$EXPLICIT_VERSION"
+          else
+            pnpm run release:bump-and-commit -- "$BUMP" "$PREID"
+          fi
+      - name: Show result (version, lockfile drift, new commit, diff)
+        run: |
+          set -euo pipefail
+          echo "after: $(node -p "require('./packages/core/package.json').version")"
+          echo "--- last commit ---"
+          git --no-pager log -1 --stat
+          echo "--- working tree status (should be clean: bump.mjs commits its files) ---"
+          git status --porcelain
+          echo "--- diff of the bump commit ---"
+          git --no-pager show --stat HEAD
+      - name: Push bump commit to disposable test branch (opt-in, never main)
+        if: ${{ inputs.do_push }}
+        env:
+          PUSH_BRANCH: ${{ inputs.push_branch }}
+        run: |
+          set -euo pipefail
+          if [ "$PUSH_BRANCH" = "main" ]; then
+            echo "::error::refusing to push to main from the test harness" >&2
+            exit 1
+          fi
+          git push --force origin "HEAD:${PUSH_BRANCH}"
+          echo "Force-pushed bump commit to ${PUSH_BRANCH}"

--- a/bump.mjs
+++ b/bump.mjs
@@ -5,7 +5,7 @@
 // `npm run release:bump -- minor`             — increment (patch | minor | major | pre*) , then sync
 // `npm run release:bump -- prerelease alpha`  — semver.inc with a preid, then sync
 // `npm run release:bump -- 2.0.0-alpha.0`     — set an explicit version, then sync
-// `npm run release:bump-and-commit -- ...`    — same, then refresh package-lock.json and git-commit
+// `npm run release:bump-and-commit -- ...`    — same, then refresh pnpm-lock.yaml and git-commit
 //
 // LOCKED packages — all four carry the SAME version and pin each other exactly:
 //   @gaunt-sloth/core, @gaunt-sloth/agent, @gaunt-sloth/review  (dirs: core/agent/review)
@@ -160,10 +160,15 @@ writePkg(appPath, app);
 console.log(`  ${'gaunt-sloth'.padEnd(9)} ${appBefore} → ${target}  (tag ${distTag})`);
 
 if (commit) {
-  // package-lock.json records the workspace versions, so refresh it or the
-  // next `npm ci` sees the lock and the package.jsons out of sync.
-  console.log('Refreshing package-lock.json');
-  execFileSync('npm', ['install', '--package-lock-only'], {
+  // pnpm-lock.yaml records the workspace importers, so refresh it or a later
+  // `pnpm install --frozen-lockfile` sees the lock and the package.jsons out of
+  // sync. This is a pnpm workspace (workspace:* cross-deps, no package-lock.json)
+  // — refreshing must go through pnpm; `npm install --package-lock-only` cannot
+  // resolve the workspace:* protocol and crashes ("Cannot read properties of
+  // null (reading 'matches')"). `--lockfile-only` updates the lock without
+  // touching node_modules, and is a no-op when nothing in the lock changed.
+  console.log('Refreshing pnpm-lock.yaml');
+  execFileSync('pnpm', ['install', '--lockfile-only'], {
     cwd: ROOT,
     stdio: 'inherit',
     shell: process.platform === 'win32',
@@ -171,7 +176,7 @@ if (commit) {
 
   const files = [
     ...ALL_DIRS.map((name) => `packages/${name}/package.json`),
-    'package-lock.json',
+    'pnpm-lock.yaml',
   ];
   const status = execFileSync('git', ['status', '--porcelain', '--', ...files], {
     cwd: ROOT,


### PR DESCRIPTION
…rkflow

The Release pipeline ships fine but the post-release bump step dies in bump.mjs --commit: it refreshed the lockfile via `npm install --package-lock-only`, but this is a pnpm workspace (workspace:* cross-deps, no package-lock.json), so npm cannot resolve the workspace:* protocol and crashes with "Cannot read properties of null (reading 'matches')". Net effect: tag + npm publish + GitHub Release go out, but main is never bumped to the next version.

- bump.mjs: refresh pnpm-lock.yaml via `pnpm install --lockfile-only` and commit pnpm-lock.yaml instead of the (nonexistent) package-lock.json.
- add .github/workflows/bump-test.yml: a workflow_dispatch harness that runs ONLY the bump+push portion in isolation (no tag/release/publish), safe by default (no push unless opted in, and only ever to a disposable branch), so the bump can be iterated to green before folding back into release.yml.


Claude-Session: https://claude.ai/code/session_01F8PhxekwiG5GfKkYZhdsaF