### PR TITLE
ci: fix YAML syntax in bump-test workflow

### DIFF
--- a/.github/workflows/bump-test.yml
+++ b/.github/workflows/bump-test.yml
@@ -82,7 +82,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Show version BEFORE bump
-        run: node -p "'before: ' + require('./packages/core/package.json').version"
+        run: |
+          echo "before: $(node -p "require('./packages/core/package.json').version")"
       - name: Run bump-and-commit (the step under test)
         env:
           BUMP: ${{ inputs.bump }}


### PR DESCRIPTION
The "Show version BEFORE bump" step used a single-line `run:` plain scalar containing `'before: '` — the colon-space made YAML parse it as a mapping key, failing the workflow lint on line 85. Switch to a block scalar.


Claude-Session: https://claude.ai/code/session_01F8PhxekwiG5GfKkYZhdsaF