### PR TITLE
feat(config): default writeOutputToFile to false

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,7 +259,7 @@ Gaunt Sloth is a command line AI assistant for software developers, primarily fo
 1. **Command Pattern**: Commands are separated into module and handler code
 2. **Provider Pattern**: Abstract interfaces for fetching content
 3. **Configuration-driven**: Heavy use of configuration files
-4. **Output Persistence**: All outputs are saved to local files
+4. **Output Persistence**: Outputs can be saved to local files (opt-in via `writeOutputToFile`; off by default)
 5. **Integration**: GitHub CLI and Jira integration for PR reviews
 
 ## Testing (Important)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Unlike autonomous coding agents or hosted review services, GSloth is a **configu
 - Interactive chat and coding sessions with filesystem access
 
 **Output handling**
-- Saves all responses to timestamped files (override with `-w/--write-output-to-file`)
+- Optionally saves responses to timestamped files (off by default; enable with `-w/--write-output-to-file`)
 - Materializes binary model outputs (e.g. generated images) as local files
 
 ### To make GSloth work, you need an **API key** from some AI provider, such as:
@@ -97,7 +97,7 @@ For detailed information about all commands, see [docs/COMMANDS.md](./docs/COMMA
 These apply to every command:
 - `--config <path>` – load a specific config file without moving directories
 - `-i, --identity-profile <name>` – switch to another profile under `.gsloth/.gsloth-settings/<name>/`
-- `-w, --write-output-to-file <value>` – control response files (`true` by default, use `-wn`/`-w0` for false, or pass a filename)
+- `-w, --write-output-to-file <value>` – control response files (`false` by default, pass `true` for standard names, `-wn`/`-w0` for false, or a filename)
 - `--verbose` – enable verbose LangChain/LangGraph logs (useful when debugging prompts)
 
 ### Available Commands:

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -12,7 +12,7 @@ Every command supports these shared flags:
 
 - `--config <path>` – load a specific configuration file (without changing directories)
 - `-i, --identity-profile <name>` – use prompts/configs from `.gsloth/.gsloth-settings/<name>/`
-- `-w, --write-output-to-file <value>` – control output files (`true` by default, use `-wn`/`-w0` for false, or pass a relative filename)
+- `-w, --write-output-to-file <value>` – control output files (`false` by default, pass `true` for standard names, `-wn`/`-w0` for false, or a relative filename)
 - `--verbose` – enable verbose LangChain/LangGraph logs for troubleshooting
 
 ## init
@@ -217,12 +217,12 @@ It is possible to press Escape during inference to interrupt it.
 - `[message]` - Initial message to start the chat
 
 ### Description
-Opens an interactive chat session where you can have a conversation with the AI. The session maintains context throughout the conversation. Chat history is saved as `gth_<timestamp>_CHAT.md` (in `.gsloth/` when present, otherwise the project root). Running `gsloth` with no subcommand starts this chat mode automatically.
+Opens an interactive chat session where you can have a conversation with the AI. The session maintains context throughout the conversation. Running `gsloth` with no subcommand starts this chat mode automatically. Writing the session to disk is off by default; enable it with `writeOutputToFile` (or `-w`) to save the history as `gth_<timestamp>_CHAT.md` (in `.gsloth/` when present, otherwise the project root).
 
 ### Features
 - Interactive conversation with context memory
 - Type 'exit' or press Ctrl+C to end the session
-- Chat history automatically saved
+- Chat history saved to file when `writeOutputToFile` is enabled
 
 ### Examples
 ```bash
@@ -247,13 +247,13 @@ It is possible to press Escape during inference to interrupt it.
 - `[message]` - Initial message to start the code session
 
 ### Description
-Opens an interactive coding session where the AI has full read access to your project files. This command is specifically designed for code writing tasks with enhanced context awareness. Code session history is saved to `gth_<timestamp>_CODE.md`.
+Opens an interactive coding session where the AI has full read access to your project files. This command is specifically designed for code writing tasks with enhanced context awareness. Writing the session to disk is off by default; enable it with `writeOutputToFile` (or `-w`) to save the history to `gth_<timestamp>_CODE.md`.
 
 ### Features
 - Full file system read access within project
 - Interactive coding session with context memory
 - Type 'exit' or press Ctrl+C to end the session
-- Code history automatically saved
+- Code history saved to file when `writeOutputToFile` is enabled
 - Streaming disabled for better interactive experience
 
 ### Examples
@@ -368,11 +368,11 @@ Commands can be configured individually in your configuration file. See [CONFIGU
 
 ## Output Files
 
-All command outputs are saved as markdown files:
+Writing command outputs to markdown files is **off by default**. Enable it with
+`-w/--write-output-to-file` or the `writeOutputToFile` config option. When enabled:
 - If `.gsloth` directory exists: Files are saved to `.gsloth/`
 - Otherwise: Files are saved to the project root
 - File naming: `gth_<timestamp>_<COMMAND>.md` for interactive sessions (same as for other commands)
-- Control this behavior with `-w/--write-output-to-file` or the `writeOutputToFile` config option.
 
 ## Exit Codes
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -70,11 +70,11 @@ fetched from the installation directory.
 
 ### Controlling Output Files
 
-By default, Gaunt Sloth writes each response to `gth_<timestamp>_<COMMAND>.md` under `.gsloth/` (or the project root).
-Set `writeOutputToFile` in your config to:
+By default, Gaunt Sloth does **not** write responses to disk. Set `writeOutputToFile` in your
+config to opt in:
 
-- `true` (default) for standard filenames,
-- `false` to skip writing files,
+- `false` (default) to skip writing files,
+- `true` to write each response to `gth_<timestamp>_<COMMAND>.md` under `.gsloth/` (or the project root),
 - a string for a custom path (behavior depends on the format):
   - **Bare filenames** (e.g. `"review.md"`) are placed in `.gsloth/` when it exists, otherwise project root
   - **Paths with separators** (e.g. `"./review.md"` or `"reviews/last.md"`) are always relative to project root

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -220,7 +220,35 @@ This is not a validation error and `gth config validate` will not flag it. It on
 when you split config across the global and project layers. `gth config print` shows the
 final merged result, which is the quickest way to confirm the effective arrays.
 
-## E. New in 2.0 (additive, nothing to migrate)
+## E. `writeOutputToFile` now defaults to `false` (behaviour change)
+
+In 1.x every command wrote its response to a timestamped `gth_<timestamp>_<COMMAND>.md`
+file (under `.gsloth/` or the project root) unless you turned it off. These files
+accumulate quickly — especially from interactive `chat`/`code` sessions, whose transcript
+you already saw live — so in 2.0 the default flips: **nothing is written to disk unless you
+opt in.**
+
+`writeOutputToFile` still accepts the same values; only the default changed:
+
+- `false` (new default) — no output file is written
+- `true` — restores the old behaviour (standard `gth_<timestamp>_<COMMAND>.md` name)
+- a string — a custom path, unchanged (see [CONFIGURATION.md](CONFIGURATION.md#controlling-output-files))
+
+**If you relied on the auto-saved files** (for example, a CI job that reads back the review
+output), set it explicitly:
+
+```json
+{
+  "writeOutputToFile": true
+}
+```
+
+**If your CI already passes an explicit value** — a string path like `"reviews/last.md"` or
+`writeOutputToFile: true`, whether in config or via `-w/--write-output-to-file` — nothing
+changes; those configs keep working exactly as before. This flip only affects setups that
+were leaning on the implicit `true` default.
+
+## F. New in 2.0 (additive, nothing to migrate)
 
 These are new capabilities, not breaking changes, but they are useful while migrating:
 
@@ -246,4 +274,6 @@ These are new capabilities, not breaking changes, but they are useful while migr
 3. Rename `*Provider*` config keys to `*Source*`, update CLI flags in scripts, and update
    any TypeScript that imported the removed provider types (C).
 4. If you split config across global + project, re-check arrays that used to merge (D).
-5. Run `gth config validate` (and optionally `gth config print`) to confirm the result.
+5. If you relied on the auto-saved `gth_<timestamp>_<COMMAND>.md` output files, set
+   `writeOutputToFile: true` (or a string path) — the default is now `false` (E).
+6. Run `gth config validate` (and optionally `gth config print`) to confirm the result.

--- a/packages/app/integration-tests/chatCommand.simple.it.ts
+++ b/packages/app/integration-tests/chatCommand.simple.it.ts
@@ -4,9 +4,11 @@ import { checkOutputForExpectedContent } from './support/outputChecker';
 
 describe('Chat Command Integration Tests', () => {
   it('should respond to initial message', async () => {
+    // writeOutputToFile now defaults to false; opt in with -w true so this test
+    // still exercises the session-logging path.
     const output = await runCommandWithArgs(
       'npx',
-      ['gth', 'chat', '"Hello, can you help me?"'],
+      ['gth', '-w', 'true', 'chat', '"Hello, can you help me?"'],
       ' >'
     );
 

--- a/packages/app/integration-tests/codeCommand.simple.it.ts
+++ b/packages/app/integration-tests/codeCommand.simple.it.ts
@@ -4,9 +4,11 @@ import { checkOutputForExpectedContent } from './support/outputChecker';
 
 describe('Code Command Integration Tests', () => {
   it('should respond to initial message', async () => {
+    // writeOutputToFile now defaults to false; opt in with -w true so this test
+    // still exercises the session-logging path.
     const output = await runCommandWithArgs(
       'npx',
-      ['gth', 'code', '"Hello, can you help me with some code?"'],
+      ['gth', '-w', 'true', 'code', '"Hello, can you help me with some code?"'],
       ' >'
     );
 

--- a/packages/core/spec/__snapshots__/config.acceptance.spec.ts.snap
+++ b/packages/core/spec/__snapshots__/config.acceptance.spec.ts.snap
@@ -156,7 +156,7 @@ exports[`effective-merged acceptance (B2b) > resolves examples/jira-mcp/.gsloth.
   "streamSessionInferenceLog": true,
   "useColour": true,
   "writeBinaryOutputsToFile": true,
-  "writeOutputToFile": true,
+  "writeOutputToFile": false,
 }
 `;
 
@@ -230,7 +230,7 @@ exports[`effective-merged acceptance (B2b) > resolves examples/lmstudio/.gsloth.
   "streamSessionInferenceLog": true,
   "useColour": true,
   "writeBinaryOutputsToFile": true,
-  "writeOutputToFile": true,
+  "writeOutputToFile": false,
 }
 `;
 
@@ -300,7 +300,7 @@ exports[`effective-merged acceptance (B2b) > resolves examples/simple-DIY-helper
   "streamSessionInferenceLog": true,
   "useColour": true,
   "writeBinaryOutputsToFile": true,
-  "writeOutputToFile": true,
+  "writeOutputToFile": false,
 }
 `;
 
@@ -376,6 +376,6 @@ exports[`effective-merged acceptance (B2b) > resolves the consumer-shaped fixtur
   "streamSessionInferenceLog": true,
   "useColour": true,
   "writeBinaryOutputsToFile": true,
-  "writeOutputToFile": true,
+  "writeOutputToFile": false,
 }
 `;

--- a/packages/core/spec/config.spec.ts
+++ b/packages/core/spec/config.spec.ts
@@ -146,7 +146,7 @@ describe('config', async () => {
         projectGuidelines: '.gsloth.guidelines.md',
         projectReviewInstructions: '.gsloth.review.md',
         streamOutput: true,
-        writeOutputToFile: true,
+        writeOutputToFile: false,
         writeBinaryOutputsToFile: true,
         useColour: true,
         filesystem: 'none',
@@ -243,7 +243,7 @@ describe('config', async () => {
         projectGuidelines: '.gsloth.guidelines.md',
         projectReviewInstructions: '.gsloth.review.md',
         streamOutput: true,
-        writeOutputToFile: true,
+        writeOutputToFile: false,
         writeBinaryOutputsToFile: true,
         useColour: true,
         filesystem: 'none',
@@ -373,7 +373,7 @@ describe('config', async () => {
         projectGuidelines: '.gsloth.guidelines.md',
         projectReviewInstructions: '.gsloth.review.md',
         streamOutput: true,
-        writeOutputToFile: true,
+        writeOutputToFile: false,
         writeBinaryOutputsToFile: true,
         useColour: true,
         filesystem: 'none',
@@ -628,8 +628,8 @@ describe('config', async () => {
       const { initConfig } = await import('#src/config.js');
       const config = await initConfig({});
 
-      // writeOutputToFile is set by neither layer -> DEFAULT_CONFIG default of true.
-      expect(config.writeOutputToFile).toBe(true);
+      // writeOutputToFile is set by neither layer -> DEFAULT_CONFIG default of false.
+      expect(config.writeOutputToFile).toBe(false);
       expect(config.useColour).toBe(true);
     });
 
@@ -644,7 +644,7 @@ describe('config', async () => {
 
       expect(config.projectGuidelines).toBe('PROJECT.md');
       // Defaults intact, no global influence.
-      expect(config.writeOutputToFile).toBe(true);
+      expect(config.writeOutputToFile).toBe(false);
       expect(config.streamOutput).toBe(true);
       // Absent global must not warn.
       expect(consoleUtilsMock.displayWarning).not.toHaveBeenCalled();
@@ -793,7 +793,7 @@ describe('config', async () => {
   });
 
   describe('writeOutputToFile configuration', () => {
-    it('Should set writeOutputToFile to true by default in config', async () => {
+    it('Should set writeOutputToFile to false by default in config', async () => {
       // Create a test config
       const jsonConfig = {
         llm: {
@@ -826,8 +826,8 @@ describe('config', async () => {
       // Function under test
       const config = await initConfig({});
 
-      // Verify that writeOutputToFile is true by default
-      expect(config.writeOutputToFile).toBe(true);
+      // Verify that writeOutputToFile is false by default
+      expect(config.writeOutputToFile).toBe(false);
     });
 
     it('Should respect writeOutputToFile setting when explicitly set to false', async () => {
@@ -1257,7 +1257,7 @@ describe('config', async () => {
         canInterruptInferenceWithEsc: true,
         streamOutput: true,
         streamSessionInferenceLog: true,
-        writeOutputToFile: true,
+        writeOutputToFile: false,
         writeBinaryOutputsToFile: true,
         useColour: true,
         filesystem: 'none',
@@ -1589,7 +1589,7 @@ describe('config', async () => {
         projectReviewInstructions: '.gsloth.review.md',
         streamOutput: true,
         streamSessionInferenceLog: true,
-        writeOutputToFile: true,
+        writeOutputToFile: false,
         writeBinaryOutputsToFile: true,
         useColour: true,
         filesystem: 'none',
@@ -1670,7 +1670,7 @@ describe('config', async () => {
         projectReviewInstructions: '.gsloth.review.md',
         streamOutput: true,
         streamSessionInferenceLog: true,
-        writeOutputToFile: true,
+        writeOutputToFile: false,
         writeBinaryOutputsToFile: true,
         useColour: true,
         filesystem: 'none',
@@ -1751,7 +1751,7 @@ describe('config', async () => {
         projectReviewInstructions: '.gsloth.review.md',
         streamOutput: true,
         streamSessionInferenceLog: true,
-        writeOutputToFile: true,
+        writeOutputToFile: false,
         writeBinaryOutputsToFile: true,
         useColour: true,
         filesystem: 'none',

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -80,7 +80,7 @@ export const DEFAULT_CONFIG = {
     },
   },
   streamOutput: true,
-  writeOutputToFile: true,
+  writeOutputToFile: false,
   writeBinaryOutputsToFile: true,
   useColour: true,
   streamSessionInferenceLog: true,

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -166,6 +166,8 @@ export interface GthConfig {
   /**
    * Should the output be written to md file.
    * (e.g. gth_2025-07-26_22-59-06_REVIEW.md).
+   * Defaults to `false` (no file is written); set to `true` for the standard
+   * `gth_<timestamp>_<COMMAND>.md` name.
    * Can be set to false with `-wn` or `-w0`
    * Can be set to a specific filename or path by passing a string:
    * - Bare filenames (e.g. `"review.md"`) are placed in `.gsloth/` when it exists, otherwise project root
@@ -479,6 +481,8 @@ export interface CommandLineConfigOverrides {
   /**
    * Should the output be written to md file.
    * (e.g. gth_2025-07-26_22-59-06_REVIEW.md).
+   * Defaults to `false` (no file is written); set to `true` for the standard
+   * `gth_<timestamp>_<COMMAND>.md` name.
    * Can be set to false with `-wn` or `-w0`
    * Can be set to a specific filename or path by passing a string:
    * - Bare filenames (e.g. `"review.md"`) are placed in `.gsloth/` when it exists, otherwise project root


### PR DESCRIPTION
## Summary

Every command previously wrote its response to a timestamped `gth_<timestamp>_<COMMAND>.md` file **by default**. These pile up quickly in the working directory — especially from interactive `chat`/`code` sessions, whose transcript you already watched live. This flips the default so file output is **opt-in**.

The `writeOutputToFile` option still accepts the same values; only the default changed:

- `false` (new default) — nothing written to disk
- `true` — restores the old behaviour (standard `gth_<timestamp>_<COMMAND>.md` name)
- string — a custom path, unchanged

Configs that set an **explicit** value are unaffected — including CI jobs that pass a string path (or `true`) via config or `-w/--write-output-to-file`. The flip only touches setups relying on the implicit `true` default.

`writeBinaryOutputsToFile` is intentionally left as `true` (its alternative is dumping raw base64 to the terminal — a different tradeoff).

## Changes

- **Default:** `DEFAULT_CONFIG.writeOutputToFile: true → false` (`packages/core/src/config/defaults.ts`)
- **Migration guide:** new section E in `docs/MIGRATION.md` documenting the behaviour change, how to restore the old behaviour, and that explicit CI string values keep working; added a migration-checklist item
- **Docs kept consistent:** `README.md`, `docs/COMMANDS.md` (chat/code descriptions + Output Files section), `docs/CONFIGURATION.md`, `AGENTS.md`, and the type JSDoc no longer claim outputs are saved by default
- **Tests:** updated the config unit tests + acceptance snapshot that asserted the old default; chat/code integration tests now pass `-w true` so they still exercise the file-writing path

## Verification

- `pnpm run build` — clean
- `pnpm run unit` — 1259 passed, 3 skipped
- `pnpm run lint` — clean
- config JSON schema regen — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NffqkzrTYtfTeyLzxGZAuJ)_