### PR TITLE
feat(agent): virtual fs by default + virtualMode-aware shell tool

### DIFF
--- a/packages/agent/spec/GthDeepAgent.spec.ts
+++ b/packages/agent/spec/GthDeepAgent.spec.ts
@@ -107,16 +107,17 @@ describe('GthDeepAgent', () => {
     expect(params.model).toBe(config.llm);
     expect(params.checkpointer).toBe(checkpointer);
     expect(params.backend).toBeInstanceOf(FilesystemBackendStub);
-    // EXT-13: the backend always runs in real-path mode now (virtualMode off); containment is
-    // enforced by the permission globs anchored at the real cwd, not the virtual-root chroot.
-    expect((params.backend as FilesystemBackendStub).options).toMatchObject({ virtualMode: false });
-    expect(params.permissions).toEqual(buildPermissions({ filesystem: 'none' }));
+    // virtualMode is the default now (no --allow-dir), so the backend runs virtual and containment
+    // is the virtual-root chroot + virtual permission globs.
+    expect((params.backend as FilesystemBackendStub).options).toMatchObject({ virtualMode: true });
+    // filesystem:'none' is virtual-agnostic (deny /** either way), so the permission shape is the same.
+    expect(params.permissions).toEqual(buildPermissions({ filesystem: 'none' }, true));
     expect(params.tools.map((t: { name: string }) => t.name)).toEqual(['foo']);
     // EXT-14: the FilesystemBackend is passed through guardFilesystemBackend before it reaches
-    // createDeepAgent (stubbed above as an identity pass-through), anchored at the real cwd.
+    // createDeepAgent (stubbed above as an identity pass-through); virtual mode by default.
     expect(deepAgentPermissions.guardFilesystemBackend).toHaveBeenCalledWith(
       expect.any(FilesystemBackendStub),
-      expect.objectContaining({ cwd: '/home/user/proj', virtual: false })
+      expect.objectContaining({ cwd: '/home/user/proj', virtual: true })
     );
   });
 
@@ -147,16 +148,16 @@ describe('GthDeepAgent', () => {
     );
   });
 
-  it('without allowDirs runs in real-path mode too (EXT-13: default cwd sandbox via globs)', async () => {
+  it('without allowDirs runs in virtualMode (virtual-by-default on all platforms)', async () => {
     const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
     const agent = new GthDeepAgent(statusUpdate, { resolveTools: vi.fn().mockResolvedValue([]) });
 
     await agent.init('exec', makeConfig({ filesystem: 'all' }));
 
     const params = createDeepAgentMock.mock.calls[0][0];
-    // EXT-13: the default sandbox no longer relies on virtualMode — the backend uses real
-    // absolute paths and the cwd allow/deny globs do the containment.
-    expect((params.backend as FilesystemBackendStub).options).toMatchObject({ virtualMode: false });
+    // Virtual is the default now: without --allow-dir the backend runs in virtualMode (cwd→`/`),
+    // and the virtualMode-aware shell tool + EXT-22 notes handle the fs-vs-shell divergence.
+    expect((params.backend as FilesystemBackendStub).options).toMatchObject({ virtualMode: true });
   });
 
   it('EXT-14: wraps the FilesystemBackend in the REAL realpath guard (not the identity stub)', async () => {
@@ -192,7 +193,7 @@ describe('GthDeepAgent', () => {
     expect(createDeepAgentMock.mock.calls[0][0].systemPrompt).toBe('SYSTEM PROMPT');
   });
 
-  it('uses the code-mode prompt for the code command and appends the EXT-13 cwd note', async () => {
+  it('uses the code-mode prompt for the code command and appends the virtualMode namespace note', async () => {
     const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
     const agent = new GthDeepAgent(statusUpdate, { resolveTools: vi.fn().mockResolvedValue([]) });
     const config = makeConfig();
@@ -201,12 +202,30 @@ describe('GthDeepAgent', () => {
 
     expect(readCodePromptMock).toHaveBeenCalledWith(config);
     expect(buildSystemMessagesMock).toHaveBeenCalledWith(config, 'code-mode-prompt');
-    // EXT-13 (part b): code mode appends the real cwd + path-model note so the model knows where
-    // it is (the fs tools + run_shell_command share one real-absolute-path namespace).
+    // Virtual by default: code mode appends the virtualMode path-namespace note (fs `/` root vs the
+    // shell's real paths), not the real-path cwd note.
     const prompt = createDeepAgentMock.mock.calls[0][0].systemPrompt as string;
     expect(prompt.startsWith('SYSTEM PROMPT')).toBe(true);
+    expect(prompt).toContain('Filesystem vs shell path namespaces:');
+    expect(prompt).toContain('is NOT a valid shell path');
+    expect(prompt).not.toContain('Working directory:');
+  });
+
+  it('code + --allow-dir (POSIX real-path mode) appends the real cwd note instead', async () => {
+    const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
+    const agent = new GthDeepAgent(statusUpdate, { resolveTools: vi.fn().mockResolvedValue([]) });
+    const config = makeConfig({ allowDirs: ['/tmp/out'] });
+
+    await agent.init('code', config);
+
+    const params = createDeepAgentMock.mock.calls[0][0];
+    // --allow-dir on a POSIX host keeps real-path mode (the fs tools + run_shell_command share one
+    // real-absolute-path namespace), so the EXT-13 real cwd note is used, not the virtual note.
+    expect((params.backend as FilesystemBackendStub).options).toMatchObject({ virtualMode: false });
+    const prompt = params.systemPrompt as string;
     expect(prompt).toContain('Working directory:');
     expect(prompt).toContain('real absolute filesystem paths');
+    expect(prompt).not.toContain('is NOT a valid shell path');
   });
 
   it('does NOT append the cwd note for non-code commands (chat keeps the bare prompt)', async () => {
@@ -228,18 +247,18 @@ describe('GthDeepAgent', () => {
     expect(createDeepAgentMock.mock.calls[0][0].systemPrompt).toBeUndefined();
   });
 
-  it('in code mode still emits the cwd note even when no other prompt content is composed', async () => {
+  it('in code mode still emits the path-namespace note even when no other prompt content is composed', async () => {
     buildSystemMessagesMock.mockReturnValue([]);
     const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
     const agent = new GthDeepAgent(statusUpdate, { resolveTools: vi.fn().mockResolvedValue([]) });
 
     await agent.init('code', makeConfig());
 
-    // EXT-13: the cwd / path-model note is essential for code mode, so it is injected even with
-    // an otherwise-empty composed prompt (no leading blank lines).
+    // The path-model note is essential for code mode, so it is injected even with an otherwise-empty
+    // composed prompt (no leading blank lines). Virtual by default → the virtualMode namespace note.
     const prompt = createDeepAgentMock.mock.calls[0][0].systemPrompt as string;
-    expect(prompt).toContain('Working directory:');
-    expect(prompt.startsWith('Working directory:')).toBe(true);
+    expect(prompt).toContain('Filesystem vs shell path namespaces:');
+    expect(prompt.startsWith('Filesystem vs shell path namespaces:')).toBe(true);
   });
 
   it('drops resolved tools that collide with deepagents filesystem tool names', async () => {
@@ -305,8 +324,13 @@ describe('GthDeepAgent', () => {
     await agent.init(undefined, config);
 
     const params = createDeepAgentMock.mock.calls[0][0];
+    // Virtual by default: the deep agent builds permissions with virtual=true, so the rules anchor
+    // at the virtual `/` root (`/src`) rather than the real cwd.
     expect(params.permissions).toEqual(
-      buildPermissions({ filesystem: ['src'], aiignore: { enabled: true, patterns: ['*.env'] } })
+      buildPermissions(
+        { filesystem: ['src'], aiignore: { enabled: true, patterns: ['*.env'] } },
+        true
+      )
     );
     // .aiignore deny rule comes first (wins over the src allow rule).
     expect(params.permissions[0].mode).toBe('deny');
@@ -702,11 +726,15 @@ describe('EXT-22 path-namespace guidance (S2 note + S1 correction middleware)', 
   // real-path note), so negative assertions can't false-pass on shared words like 'run_shell_command'.
   const VIRTUAL_ONLY_MARKER = 'is NOT a valid shell path';
 
-  async function initAgent(command: 'code' | 'chat', cwd: string) {
+  async function initAgent(
+    command: 'code' | 'chat',
+    cwd: string,
+    configOver: Partial<GthConfig> = {}
+  ) {
     getCurrentWorkDirMock.mockReturnValue(cwd);
     const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
     const agent = new GthDeepAgent(statusUpdate, { resolveTools: vi.fn().mockResolvedValue([]) });
-    await agent.init(command, makeConfig());
+    await agent.init(command, makeConfig(configOver));
     return createDeepAgentMock.mock.calls[0][0];
   }
 
@@ -732,8 +760,9 @@ describe('EXT-22 path-namespace guidance (S2 note + S1 correction middleware)', 
     expect(prompt).toContain('Host operating system:');
   });
 
-  it('S2: code + real-path (POSIX) keeps the EXT-13 note and NOT the virtualMode guidance', async () => {
-    const params = await initAgent('code', '/home/user/proj');
+  it('S2: code + real-path (POSIX, via --allow-dir) keeps the EXT-13 note and NOT the virtualMode guidance', async () => {
+    // Virtual is the default on POSIX now, so real-path mode must be forced with --allow-dir.
+    const params = await initAgent('code', '/home/user/proj', { allowDirs: ['/tmp/out'] });
     const prompt = params.systemPrompt as string;
     expect(prompt).toContain('Working directory:');
     expect(prompt).toContain('there is no virtual root'); // EXT-13 real-path note
@@ -790,8 +819,9 @@ describe('EXT-22 path-namespace guidance (S2 note + S1 correction middleware)', 
     }
   });
 
-  it('S1: transparent pass-through in code + real-path (POSIX) — request untouched', async () => {
-    const params = await initAgent('code', '/home/user/proj');
+  it('S1: transparent pass-through in code + real-path (POSIX, via --allow-dir) — request untouched', async () => {
+    // Real-path mode on POSIX now requires --allow-dir (virtual is the default).
+    const params = await initAgent('code', '/home/user/proj', { allowDirs: ['/tmp/out'] });
     const mw = lastMiddleware(params);
     const request = { systemMessage: new SystemMessage('BASE PROMPT') };
     const handler = vi.fn().mockResolvedValue('r');

--- a/packages/agent/spec/GthDevToolkit.simple.spec.ts
+++ b/packages/agent/spec/GthDevToolkit.simple.spec.ts
@@ -154,31 +154,51 @@ describe('GthDevToolkit - Basic Tests', () => {
       expect(shellTool.description).not.toContain('VIRTUAL');
     });
 
-    it('in virtualFs mode augments the description and forces the acknowledgement param', async () => {
+    it('in virtualFs mode augments the description and adds the acknowledgement param', async () => {
       const { VIRTUAL_FS_SHELL_ACK_PARAM } = await import('#src/tools/GthDevToolkit.js');
       toolkit = new GthDevToolkit({ shell: true }, 'code', { virtualFs: true });
       const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command')!;
-      // The forced acknowledgement param is present alongside `command`...
+      // The acknowledgement param is present alongside `command` and is required at the schema level.
       const shape = (shellTool.schema as any).shape ?? {};
       expect(Object.keys(shape)).toContain('command');
       expect(Object.keys(shape)).toContain(VIRTUAL_FS_SHELL_ACK_PARAM);
-      // ...and it only accepts literal `true` (the "forced boolean").
       expect((shellTool.schema as any).safeParse({ command: 'ls' }).success).toBe(false);
+      // It is a PLAIN boolean (not z.literal(true)), so it emits no JSON-Schema `const` — Vertex AI
+      // rejects `const`. The "only true" constraint is enforced at runtime, not by the schema, so a
+      // `false` value still parses (it is refused when the tool runs; see below).
       expect(
         (shellTool.schema as any).safeParse({
           command: 'ls',
           [VIRTUAL_FS_SHELL_ACK_PARAM]: false,
         }).success
-      ).toBe(false);
-      expect(
-        (shellTool.schema as any).safeParse({
-          command: 'ls',
-          [VIRTUAL_FS_SHELL_ACK_PARAM]: true,
-        }).success
       ).toBe(true);
       // The description warns about the virtual `/` root vs real shell paths.
       expect(shellTool.description).toContain('VIRTUAL');
       expect(shellTool.description).toContain(VIRTUAL_FS_SHELL_ACK_PARAM);
+    });
+
+    it('emits no JSON-Schema `const`/`enum` in the ack param (Vertex AI compatibility)', async () => {
+      const { z } = await import('zod');
+      toolkit = new GthDevToolkit({ shell: true }, 'code', { virtualFs: true });
+      const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command')!;
+      const json = JSON.stringify(z.toJSONSchema(shellTool.schema as any));
+      expect(json).not.toContain('"const"');
+      // No boolean-valued enum either (Vertex only tolerates enum on strings).
+      expect(json).not.toContain('"enum":[true]');
+    });
+
+    it('in virtualFs mode refuses (recoverably) when the acknowledgement is not true', async () => {
+      const { VIRTUAL_FS_SHELL_ACK_PARAM } = await import('#src/tools/GthDevToolkit.js');
+      toolkit = new GthDevToolkit({ shell: true }, 'code', { virtualFs: true });
+      const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command')!;
+      const result = await shellTool.invoke({
+        command: 'echo hi',
+        [VIRTUAL_FS_SHELL_ACK_PARAM]: false,
+      });
+      // A recoverable message (not an exception, not a spawn): the command must not have run.
+      expect(result).toContain(VIRTUAL_FS_SHELL_ACK_PARAM);
+      expect(result).toContain('Command not run');
+      expect(result).not.toContain('completed successfully');
     });
 
     it('in virtualFs mode still runs the command once acknowledged', async () => {

--- a/packages/agent/spec/GthDevToolkit.simple.spec.ts
+++ b/packages/agent/spec/GthDevToolkit.simple.spec.ts
@@ -145,70 +145,34 @@ describe('GthDevToolkit - Basic Tests', () => {
       expect(toolkit.tools.map((t) => t.name)).not.toContain('run_shell_command');
     });
 
-    it('by default (virtualFs off) emits the plain single-parameter tool (no ack param)', () => {
+    it('keeps the same single-parameter schema in both plain and virtualFs mode', () => {
+      // The virtualMode awareness is description-only: no extra tool parameter is added, so there is
+      // nothing unusual for a provider's tool-schema validation (or the model) to trip over.
+      for (const virtualFs of [false, true]) {
+        const t = new GthDevToolkit({ shell: true }, 'code', { virtualFs });
+        const shellTool = t.tools.find((x) => x.name === 'run_shell_command')!;
+        expect(Object.keys((shellTool.schema as any).shape ?? {})).toEqual(['command']);
+      }
+    });
+
+    it('by default (virtualFs off) uses the plain description (no path-namespace warning)', () => {
       toolkit = new GthDevToolkit({ shell: true });
       const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command')!;
-      const shape = (shellTool.schema as any).shape ?? {};
-      expect(Object.keys(shape)).toEqual(['command']);
-      // Description does NOT carry the virtualMode path-namespace warning.
       expect(shellTool.description).not.toContain('VIRTUAL');
     });
 
-    it('in virtualFs mode augments the description and adds the acknowledgement param', async () => {
-      const { VIRTUAL_FS_SHELL_ACK_PARAM } = await import('#src/tools/GthDevToolkit.js');
+    it('in virtualFs mode augments the description with the fs-vs-shell path warning', () => {
       toolkit = new GthDevToolkit({ shell: true }, 'code', { virtualFs: true });
       const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command')!;
-      // The acknowledgement param is present alongside `command` and is required at the schema level.
-      const shape = (shellTool.schema as any).shape ?? {};
-      expect(Object.keys(shape)).toContain('command');
-      expect(Object.keys(shape)).toContain(VIRTUAL_FS_SHELL_ACK_PARAM);
-      expect((shellTool.schema as any).safeParse({ command: 'ls' }).success).toBe(false);
-      // It is a PLAIN boolean (not z.literal(true)), so it emits no JSON-Schema `const` — Vertex AI
-      // rejects `const`. The "only true" constraint is enforced at runtime, not by the schema, so a
-      // `false` value still parses (it is refused when the tool runs; see below).
-      expect(
-        (shellTool.schema as any).safeParse({
-          command: 'ls',
-          [VIRTUAL_FS_SHELL_ACK_PARAM]: false,
-        }).success
-      ).toBe(true);
-      // The description warns about the virtual `/` root vs real shell paths.
+      // Warns that fs paths are virtual and steers the model to verify the real cwd (pwd/cd).
       expect(shellTool.description).toContain('VIRTUAL');
-      expect(shellTool.description).toContain(VIRTUAL_FS_SHELL_ACK_PARAM);
+      expect(shellTool.description).toContain(process.platform === 'win32' ? '`cd`' : '`pwd`');
     });
 
-    it('emits no JSON-Schema `const`/`enum` in the ack param (Vertex AI compatibility)', async () => {
-      const { z } = await import('zod');
+    it('in virtualFs mode runs the command normally (schema unchanged)', async () => {
       toolkit = new GthDevToolkit({ shell: true }, 'code', { virtualFs: true });
       const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command')!;
-      const json = JSON.stringify(z.toJSONSchema(shellTool.schema as any));
-      expect(json).not.toContain('"const"');
-      // No boolean-valued enum either (Vertex only tolerates enum on strings).
-      expect(json).not.toContain('"enum":[true]');
-    });
-
-    it('in virtualFs mode refuses (recoverably) when the acknowledgement is not true', async () => {
-      const { VIRTUAL_FS_SHELL_ACK_PARAM } = await import('#src/tools/GthDevToolkit.js');
-      toolkit = new GthDevToolkit({ shell: true }, 'code', { virtualFs: true });
-      const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command')!;
-      const result = await shellTool.invoke({
-        command: 'echo hi',
-        [VIRTUAL_FS_SHELL_ACK_PARAM]: false,
-      });
-      // A recoverable message (not an exception, not a spawn): the command must not have run.
-      expect(result).toContain(VIRTUAL_FS_SHELL_ACK_PARAM);
-      expect(result).toContain('Command not run');
-      expect(result).not.toContain('completed successfully');
-    });
-
-    it('in virtualFs mode still runs the command once acknowledged', async () => {
-      const { VIRTUAL_FS_SHELL_ACK_PARAM } = await import('#src/tools/GthDevToolkit.js');
-      toolkit = new GthDevToolkit({ shell: true }, 'code', { virtualFs: true });
-      const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command')!;
-      const result = await shellTool.invoke({
-        command: 'echo hi',
-        [VIRTUAL_FS_SHELL_ACK_PARAM]: true,
-      });
+      const result = await shellTool.invoke({ command: 'echo hi' });
       expect(result).toContain("Command 'echo hi' completed successfully");
     });
 

--- a/packages/agent/spec/GthDevToolkit.simple.spec.ts
+++ b/packages/agent/spec/GthDevToolkit.simple.spec.ts
@@ -145,6 +145,53 @@ describe('GthDevToolkit - Basic Tests', () => {
       expect(toolkit.tools.map((t) => t.name)).not.toContain('run_shell_command');
     });
 
+    it('by default (virtualFs off) emits the plain single-parameter tool (no ack param)', () => {
+      toolkit = new GthDevToolkit({ shell: true });
+      const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command')!;
+      const shape = (shellTool.schema as any).shape ?? {};
+      expect(Object.keys(shape)).toEqual(['command']);
+      // Description does NOT carry the virtualMode path-namespace warning.
+      expect(shellTool.description).not.toContain('VIRTUAL');
+    });
+
+    it('in virtualFs mode augments the description and forces the acknowledgement param', async () => {
+      const { VIRTUAL_FS_SHELL_ACK_PARAM } = await import('#src/tools/GthDevToolkit.js');
+      toolkit = new GthDevToolkit({ shell: true }, 'code', { virtualFs: true });
+      const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command')!;
+      // The forced acknowledgement param is present alongside `command`...
+      const shape = (shellTool.schema as any).shape ?? {};
+      expect(Object.keys(shape)).toContain('command');
+      expect(Object.keys(shape)).toContain(VIRTUAL_FS_SHELL_ACK_PARAM);
+      // ...and it only accepts literal `true` (the "forced boolean").
+      expect((shellTool.schema as any).safeParse({ command: 'ls' }).success).toBe(false);
+      expect(
+        (shellTool.schema as any).safeParse({
+          command: 'ls',
+          [VIRTUAL_FS_SHELL_ACK_PARAM]: false,
+        }).success
+      ).toBe(false);
+      expect(
+        (shellTool.schema as any).safeParse({
+          command: 'ls',
+          [VIRTUAL_FS_SHELL_ACK_PARAM]: true,
+        }).success
+      ).toBe(true);
+      // The description warns about the virtual `/` root vs real shell paths.
+      expect(shellTool.description).toContain('VIRTUAL');
+      expect(shellTool.description).toContain(VIRTUAL_FS_SHELL_ACK_PARAM);
+    });
+
+    it('in virtualFs mode still runs the command once acknowledged', async () => {
+      const { VIRTUAL_FS_SHELL_ACK_PARAM } = await import('#src/tools/GthDevToolkit.js');
+      toolkit = new GthDevToolkit({ shell: true }, 'code', { virtualFs: true });
+      const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command')!;
+      const result = await shellTool.invoke({
+        command: 'echo hi',
+        [VIRTUAL_FS_SHELL_ACK_PARAM]: true,
+      });
+      expect(result).toContain("Command 'echo hi' completed successfully");
+    });
+
     it('runs the model-supplied command verbatim (no parameter sanitizing)', async () => {
       toolkit = new GthDevToolkit({ shell: true });
       const shellTool = toolkit.tools.find((t) => t.name === 'run_shell_command')!;

--- a/packages/agent/src/builtInToolsConfig.ts
+++ b/packages/agent/src/builtInToolsConfig.ts
@@ -84,7 +84,7 @@ async function filterDevTools(
     return [];
   }
   // Pass the command so GthDevToolkit resolves the shell default for the active mode, and the
-  // virtualFs flag so the shell tool warns + forces acknowledgement when fs paths are virtual.
+  // virtualFs flag so the shell tool's description warns about the fs-vs-shell path divergence.
   const toolkit = new GthDevToolkit(devToolConfig ?? {}, command, { virtualFs });
   return [...toolkit.getTools()];
 }

--- a/packages/agent/src/builtInToolsConfig.ts
+++ b/packages/agent/src/builtInToolsConfig.ts
@@ -55,14 +55,22 @@ export async function getDefaultTools(
       : askWrite
         ? config.commands?.ask?.devTools
         : config.commands?.code?.devTools;
-  const devTools = await filterDevTools(askWrite ? 'code' : command, devToolConfig);
+  // `config.deepFsVirtual` is set (transient) by the deep agent when its fs backend runs in
+  // virtualMode; it makes the shared shell tool advertise the fs-vs-shell path divergence. Absent
+  // on the lean path (real fs paths, no divergence), so the plain shell tool is emitted there.
+  const devTools = await filterDevTools(
+    askWrite ? 'code' : command,
+    devToolConfig,
+    config.deepFsVirtual === true
+  );
   const customTools = getCustomTools(config, command);
   return [...filesystemTools, ...devTools, ...customTools, ...builtInTools];
 }
 
 async function filterDevTools(
   command: GthCommand | undefined,
-  devToolConfig: GthDevToolsConfig | undefined
+  devToolConfig: GthDevToolsConfig | undefined,
+  virtualFs: boolean
 ): Promise<StructuredToolInterface[]> {
   // Dev tools only apply to the do-the-job commands (`code` / `exec`; `ask --write` is mapped
   // to `code` by the caller). EXT-12: for `code` the toolkit is constructed even when no
@@ -75,8 +83,9 @@ async function filterDevTools(
   if (command === 'exec' && !devToolConfig) {
     return [];
   }
-  // Pass the command so GthDevToolkit resolves the shell default for the active mode.
-  const toolkit = new GthDevToolkit(devToolConfig ?? {}, command);
+  // Pass the command so GthDevToolkit resolves the shell default for the active mode, and the
+  // virtualFs flag so the shell tool warns + forces acknowledgement when fs paths are virtual.
+  const toolkit = new GthDevToolkit(devToolConfig ?? {}, command, { virtualFs });
   return [...toolkit.getTools()];
 }
 

--- a/packages/agent/src/core/GthDeepAgent.ts
+++ b/packages/agent/src/core/GthDeepAgent.ts
@@ -33,9 +33,9 @@ import { ShellCommandFailedError } from '#src/tools/GthDevToolkit.js';
  * deepagents' native, cross-platform-uniform behavior and the pre-EXT-13 known-good path. This
  * supersedes the EXT-13 default (which ran POSIX in real-path mode to share ONE namespace with the
  * shell). Under virtualMode the fs tools' virtual `/` root and `run_shell_command`'s real OS paths
- * DIVERGE, so the shell tool is made virtualMode-aware (an augmented description plus a forced
- * acknowledgement parameter — see GthDevToolkit) and the EXT-22 path-namespace notes/correction
- * apply on all platforms, not just Windows.
+ * DIVERGE, so the shell tool is made virtualMode-aware (its description warns about the divergence
+ * and steers toward verifying the real cwd — see GthDevToolkit) and the EXT-22 path-namespace
+ * notes/correction apply on all platforms, not just Windows.
  *
  * Two cases still force real-path mode instead of virtual:
  *  - The real cwd is not POSIX `/`-rooted (e.g. Windows `D:\...`). deepagents' permission layer
@@ -344,8 +344,8 @@ export class GthDeepAgent extends GthAbstractAgent {
     // enforcement entirely — a model could read an .aiignore-protected file through them.
     debugLog('Resolving tools (filesystem disabled; deepagents provides fs)...');
     // Tell the shared dev toolkit whether the fs backend runs in virtualMode for this run, so its
-    // run_shell_command tool warns about the fs-vs-shell path divergence and forces an explicit
-    // acknowledgement. Computed from the effective config (mirrors init()'s useVirtualFs).
+    // run_shell_command tool's description warns about the fs-vs-shell path divergence. Computed
+    // from the effective config (mirrors init()'s useVirtualFs).
     const useVirtualFs = shouldUseVirtualFs(this.config ?? undefined);
     const toolResolutionConfig = {
       ...this.config,

--- a/packages/agent/src/core/GthDeepAgent.ts
+++ b/packages/agent/src/core/GthDeepAgent.ts
@@ -27,18 +27,32 @@ import type { DebugCapture, DebugRequestExtras, DebugToolDef } from '#src/core/d
 import { ShellCommandFailedError } from '#src/tools/GthDevToolkit.js';
 
 /**
- * EXT-16: decide whether the deepagents filesystem backend must run in virtualMode.
+ * Decide whether the deepagents filesystem backend runs in virtualMode.
  *
- * deepagents' permission layer (`validatePath`) requires POSIX `/`-rooted glob paths, and its
- * fs tools hand the SAME model-supplied path string to both the permission check and the native
- * `path.resolve`/`fs` backend. On Windows a real cwd is `D:\...`, which can satisfy neither side
- * as one string, so the EXT-13 real-path sandbox throws `Error: path must be absolute` on every
- * turn and the agent hangs. The precise trigger is "the real cwd is not POSIX-rooted", so we key
- * off that directly (not just `win32`): when true, run virtualMode (cwd→`/`) with virtual
- * permissions — the pre-EXT-13 known-good behavior. POSIX keeps the EXT-13 real-path namespace.
+ * virtualMode (cwd→`/`, virtual permissions) is now the DEFAULT on every platform — it is
+ * deepagents' native, cross-platform-uniform behavior and the pre-EXT-13 known-good path. This
+ * supersedes the EXT-13 default (which ran POSIX in real-path mode to share ONE namespace with the
+ * shell). Under virtualMode the fs tools' virtual `/` root and `run_shell_command`'s real OS paths
+ * DIVERGE, so the shell tool is made virtualMode-aware (an augmented description plus a forced
+ * acknowledgement parameter — see GthDevToolkit) and the EXT-22 path-namespace notes/correction
+ * apply on all platforms, not just Windows.
+ *
+ * Two cases still force real-path mode instead of virtual:
+ *  - The real cwd is not POSIX `/`-rooted (e.g. Windows `D:\...`). deepagents' permission layer
+ *    (`validatePath`) requires POSIX `/`-rooted globs, so a non-POSIX cwd could never run real-path
+ *    mode anyway (was EXT-16) — it MUST be virtual. (This branch and the default now agree, but it
+ *    is kept explicit for clarity.)
+ *  - `--allow-dir` widening is requested on a POSIX host: reaching directories OUTSIDE cwd needs
+ *    REAL absolute paths that a virtual `/` root cannot express, so keep real-path mode there (the
+ *    EXT-13/EXT-14 real-path sandbox, unchanged) so widening still works.
  */
-function shouldUseVirtualFs(): boolean {
-  return !getCurrentWorkDir().startsWith('/');
+function shouldUseVirtualFs(config?: { allowDirs?: unknown }): boolean {
+  // Non-POSIX real cwd (Windows) can never be expressed as deepagents' POSIX `/`-rooted permission
+  // globs → must run virtual.
+  if (!getCurrentWorkDir().startsWith('/')) return true;
+  // POSIX: virtual by default; real-path only when `--allow-dir` widening needs real absolute paths.
+  const widen = Array.isArray(config?.allowDirs) && (config.allowDirs as unknown[]).length > 0;
+  return !widen;
 }
 
 /**
@@ -172,13 +186,12 @@ export class GthDeepAgent extends GthAbstractAgent {
       },
     });
 
-    // EXT-16: whether the deepagents fs backend runs in virtualMode. deepagents' permission layer
-    // requires POSIX `/`-rooted paths, so a Windows real cwd (`D:\...`) can't be expressed as a
-    // permission glob and the EXT-13 real-path mode hangs there (`Error: path must be absolute`).
-    // When the real cwd isn't POSIX-rooted, fall back to virtualMode (cwd→`/`) with virtual
-    // permissions — the pre-EXT-13 known-good Windows behavior. Computed here because the EXT-22 S1
-    // middleware (below), the backend, and the systemPrompt gate (further down) all key off it.
-    const useVirtualFs = shouldUseVirtualFs();
+    // Whether the deepagents fs backend runs in virtualMode. virtualMode is now the default on all
+    // platforms; real-path mode is retained only for a non-POSIX cwd (Windows) — where it is forced
+    // virtual — and for POSIX `--allow-dir` widening (which needs real absolute paths). Computed
+    // from the effective config because the EXT-22 S1 middleware (below), the backend, and the
+    // systemPrompt gate (further down) all key off it. See shouldUseVirtualFs.
+    const useVirtualFs = shouldUseVirtualFs(this.config ?? undefined);
 
     // EXT-22 (S1): last-word path-namespace correction. Appends the shared guidance as a trailing
     // system-message block ONLY in code + virtualMode (where the fs virtual `/` root and the
@@ -199,13 +212,14 @@ export class GthDeepAgent extends GthAbstractAgent {
       `Loaded middleware: ${middleware.map((m) => m.name).join(', ')}`
     );
 
-    // EXT-13: the backend always runs in REAL-path mode (virtualMode off) so the deepagents fs
-    // tools and the EXT-9 run_shell_command tool share ONE path namespace — real absolute paths
-    // rooted at cwd. Containment is enforced by the permission allow/deny globs built in
-    // buildDeepAgentParams (default: allow cwd/**, deny /**), which match what virtualMode used to
-    // give for free (see deepAgentPermissions + the EXT-13 symlink/`..` parity tests), PLUS the
-    // EXT-14 realpath guard wrapped around the backend below (closes the intermediate-symlinked-
-    // directory gap those lexical globs alone can't catch).
+    // The backend runs in virtualMode by default (useVirtualFs) — the deepagents fs tools address a
+    // virtual `/` root (= cwd) while run_shell_command uses real OS paths; the divergence is handled
+    // by the virtualMode-aware shell tool + the EXT-22 path-namespace notes. Real-path mode (the
+    // EXT-13/EXT-14 sandbox) is retained for POSIX `--allow-dir` widening, where the fs tools and
+    // shell share ONE real-absolute-path namespace rooted at cwd. Containment in real-path mode is
+    // enforced by the permission allow/deny globs built in buildDeepAgentParams (default: allow
+    // cwd/**, deny /**) PLUS the EXT-14 realpath guard wrapped around the backend below; in
+    // virtualMode the virtual-root chroot + virtual permission globs do it (as they always have).
     // `--allow-dir` (config.allowDirs) further widens those allow-rules to reach extra real dirs;
     // it removes a guardrail, so it is announced loudly by the exec command and surfaced here.
     const allowDirs = this.config?.allowDirs;
@@ -326,7 +340,15 @@ export class GthDeepAgent extends GthAbstractAgent {
     // delete_file, search_files, …) would otherwise bypass deepagents' permission
     // enforcement entirely — a model could read an .aiignore-protected file through them.
     debugLog('Resolving tools (filesystem disabled; deepagents provides fs)...');
-    const toolResolutionConfig = { ...this.config, filesystem: 'none' as const };
+    // Tell the shared dev toolkit whether the fs backend runs in virtualMode for this run, so its
+    // run_shell_command tool warns about the fs-vs-shell path divergence and forces an explicit
+    // acknowledgement. Computed from the effective config (mirrors init()'s useVirtualFs).
+    const useVirtualFs = shouldUseVirtualFs(this.config ?? undefined);
+    const toolResolutionConfig = {
+      ...this.config,
+      filesystem: 'none' as const,
+      deepFsVirtual: useVirtualFs,
+    };
     const resolvedTools =
       !toolsDisabled && this.resolvers?.resolveTools
         ? await this.resolvers.resolveTools(toolResolutionConfig, command)
@@ -504,9 +526,10 @@ export class GthDeepAgent extends GthAbstractAgent {
             ? this.config.allowDirs
             : undefined,
       },
-      // EXT-16: build virtual (`/`-rooted) permission rules when the backend will run in
-      // virtualMode (Windows), matching the FilesystemBackend created in init().
-      shouldUseVirtualFs()
+      // Build virtual (`/`-rooted) permission rules when the backend will run in virtualMode (the
+      // default; also every non-POSIX cwd), matching the FilesystemBackend created in init(). Reuses
+      // the same useVirtualFs computed above so tools, permissions and backend stay in lockstep.
+      useVirtualFs
     );
     debugLogObject('Filesystem permissions', permissions);
 
@@ -606,13 +629,16 @@ export const PATH_NAMESPACE_GUIDANCE =
   'this session: a leading `/` means your working directory, and their paths are written ' +
   '`/`-rooted relative to it (this is what "all file paths must start with a /" refers to). That ' +
   '`/` is NOT the real operating-system filesystem root. run_shell_command is different: it runs ' +
-  'in the real operating system and uses real native paths (on Windows, e.g. ' +
-  '`C:\\Users\\...\\project`, with backslashes), never the virtual `/` root. A `/`-rooted path ' +
-  'from the filesystem tools is NOT a valid shell path and must never be passed to ' +
-  'run_shell_command. The one form that means the same thing to both tool families is a path ' +
-  'RELATIVE to the working directory (e.g. `src/index.ts`); prefer relative paths for both. When ' +
-  'you must be absolute, use `/`-rooted form ONLY for the filesystem tools and real native form ' +
-  'ONLY for run_shell_command.';
+  'in the real operating system and uses real native paths, never the virtual `/` root. On Windows ' +
+  'those look obviously different (e.g. `C:\\Users\\...\\project`, with backslashes); on Linux/macOS ' +
+  'the real working directory is ITSELF an absolute path such as `/home/you/project`, so a virtual ' +
+  '`/src/index.ts` actually lives at `<working dir>/src/index.ts` for the shell — the two `/`-forms ' +
+  'look identical but mean different things, which is easy to get wrong. A `/`-rooted path from the ' +
+  'filesystem tools is NOT a valid shell path and must never be passed to run_shell_command. The ' +
+  'one form that means the same thing to both tool families is a path RELATIVE to the working ' +
+  'directory (e.g. `src/index.ts`); prefer relative paths for both. When you must be absolute, use ' +
+  '`/`-rooted form ONLY for the filesystem tools and real native form ONLY for run_shell_command ' +
+  '(confirm the real working directory with a shell command such as `pwd` first).';
 
 /**
  * EXT-22 (S2): virtualMode variant of {@link appendCwdNote}. On the `code` path when the fs

--- a/packages/agent/src/tools/GthDevToolkit.ts
+++ b/packages/agent/src/tools/GthDevToolkit.ts
@@ -129,21 +129,27 @@ export const VIRTUAL_FS_SHELL_ACK_PARAM =
 
 /**
  * virtualMode variant of {@link RunShellCommandArgsSchema}. In addition to `command` it carries a
- * FORCED acknowledgement flag ({@link VIRTUAL_FS_SHELL_ACK_PARAM}) typed as `z.literal(true)` — it
- * is required and only accepts `true`, so the model cannot call the shell tool without first
- * consciously acknowledging that a filesystem-tool `/`-rooted path is NOT necessarily a valid path
- * for this real-OS shell.
+ * FORCED acknowledgement flag ({@link VIRTUAL_FS_SHELL_ACK_PARAM}) so the model cannot call the
+ * shell tool without first consciously acknowledging that a filesystem-tool `/`-rooted path is NOT
+ * necessarily a valid path for this real-OS shell.
+ *
+ * The flag is a plain required `z.boolean()`, NOT `z.literal(true)`: a literal emits a JSON-Schema
+ * `const`, which Gemini/Vertex AI's function-declaration schema dialect rejects ("Unknown name
+ * `const`"), poisoning the whole request. Keeping it a bare boolean produces only `{"type":
+ * "boolean"}`, which every provider accepts. The "only true is allowed" constraint is enforced at
+ * RUNTIME instead (see the tool body in `createTools`), which returns a recoverable message rather
+ * than aborting when the model passes anything but `true`.
  */
 const RunShellCommandVirtualArgsSchema = z.object({
   command: z.string().describe('The shell command to run'),
   [VIRTUAL_FS_SHELL_ACK_PARAM]: z
-    .literal(true)
+    .boolean()
     .describe(
-      'Required — must be true. By setting this to true you confirm you understand that the ' +
+      'Required — you MUST pass true. By setting this to true you confirm you understand that the ' +
         'filesystem tools (ls/read_file/write_file/edit_file/glob/grep) address a VIRTUAL "/" root ' +
         '(a leading "/" means the working directory) which can differ from the real native paths ' +
         'this shell uses, and that you have verified — or will verify — the real working directory ' +
-        'before relying on any path in the command.'
+        'before relying on any path in the command. The command will NOT run unless this is true.'
     ),
 });
 
@@ -522,15 +528,27 @@ export default class GthDevToolkit extends BaseToolkit {
     if (isShellToolEnabled(this.commands, this.command)) {
       // In virtualMode the fs tools' `/` root diverges from this shell's real OS paths, so the
       // shell tool warns about it (description) AND forces an explicit per-call acknowledgement
-      // (VIRTUAL_FS_SHELL_ACK_PARAM). The command runner ignores the ack flag — its only job is to
-      // make the model stop and think about the path namespace before every shell call. The plain
-      // (non-virtual) path keeps the original single-parameter tool unchanged.
-      const shellSchema = this.virtualFs
-        ? RunShellCommandVirtualArgsSchema
-        : RunShellCommandArgsSchema;
+      // (VIRTUAL_FS_SHELL_ACK_PARAM). The "only true is accepted" rule is enforced HERE at runtime
+      // (not via a schema literal, which would emit a Vertex-incompatible `const`): a missing/false
+      // ack returns a recoverable message so the model retries with it set, rather than aborting.
+      // The plain (non-virtual) path keeps the original single-parameter tool unchanged.
+      const virtualFs = this.virtualFs;
+      const shellSchema = virtualFs ? RunShellCommandVirtualArgsSchema : RunShellCommandArgsSchema;
       tools.push(
         createGthTool(
           async (args: z.infer<typeof shellSchema>): Promise<string> => {
+            if (
+              virtualFs &&
+              (args as Record<string, unknown>)[VIRTUAL_FS_SHELL_ACK_PARAM] !== true
+            ) {
+              return (
+                `Command not run. You must set \`${VIRTUAL_FS_SHELL_ACK_PARAM}: true\` to ` +
+                'acknowledge that the filesystem tools address a virtual "/" root that can differ ' +
+                "from this shell's real paths. Confirm the real working directory first (run " +
+                `${printWorkDirCommand()}), then retry this command with the acknowledgement set ` +
+                'to true.'
+              );
+            }
             return await this.executeCommand(args.command, 'run_shell_command');
           },
           {

--- a/packages/agent/src/tools/GthDevToolkit.ts
+++ b/packages/agent/src/tools/GthDevToolkit.ts
@@ -118,7 +118,72 @@ const RunShellCommandArgsSchema = z.object({
   command: z.string().describe('The shell command to run'),
 });
 
+/**
+ * The name of the forced acknowledgement parameter added to `run_shell_command` when the deep
+ * agent's filesystem tools run in virtualMode. Intentionally a long, self-describing name: the
+ * model reads it on every shell call as a reminder that the fs-tool `/` root and the shell's real
+ * paths are two different namespaces.
+ */
+export const VIRTUAL_FS_SHELL_ACK_PARAM =
+  'i_acknowledge_that_fs_tools_are_in_virtual_mode_and_paths_could_be_different_from_shell';
+
+/**
+ * virtualMode variant of {@link RunShellCommandArgsSchema}. In addition to `command` it carries a
+ * FORCED acknowledgement flag ({@link VIRTUAL_FS_SHELL_ACK_PARAM}) typed as `z.literal(true)` — it
+ * is required and only accepts `true`, so the model cannot call the shell tool without first
+ * consciously acknowledging that a filesystem-tool `/`-rooted path is NOT necessarily a valid path
+ * for this real-OS shell.
+ */
+const RunShellCommandVirtualArgsSchema = z.object({
+  command: z.string().describe('The shell command to run'),
+  [VIRTUAL_FS_SHELL_ACK_PARAM]: z
+    .literal(true)
+    .describe(
+      'Required — must be true. By setting this to true you confirm you understand that the ' +
+        'filesystem tools (ls/read_file/write_file/edit_file/glob/grep) address a VIRTUAL "/" root ' +
+        '(a leading "/" means the working directory) which can differ from the real native paths ' +
+        'this shell uses, and that you have verified — or will verify — the real working directory ' +
+        'before relying on any path in the command.'
+    ),
+});
+
 const TEST_PATH_PLACEHOLDER = '${testPath}';
+
+/**
+ * The command that prints the real working directory in the shell `run_shell_command` spawns
+ * (`cmd.exe` on Windows, `/bin/sh` on POSIX). Used in the virtualMode shell-tool description so the
+ * model is told exactly how to confirm where it really is before trusting a path.
+ */
+function printWorkDirCommand(): string {
+  return process.platform === 'win32' ? '`cd` (with no arguments)' : '`pwd`';
+}
+
+/** Base description shared by both the plain and the virtualMode `run_shell_command` tool. */
+const RUN_SHELL_COMMAND_BASE_DESCRIPTION =
+  'Run an arbitrary shell command in the project working directory and return its ' +
+  'combined stdout/stderr and exit status. Use for any task the fixed run_* tools do ' +
+  'not cover (e.g. git, package managers, file inspection). Each call is subject to ' +
+  'human approval before it runs unless approval has been disabled.';
+
+/**
+ * The virtualMode `run_shell_command` description. Appends a path-namespace warning to the base
+ * description: the filesystem tools use a virtual `/` root while this shell uses real native OS
+ * paths, so the model must verify the real working directory (`pwd` / `cd`) before putting any path
+ * into a shell command and should prefer paths relative to the working directory.
+ */
+function buildVirtualShellDescription(): string {
+  return (
+    RUN_SHELL_COMMAND_BASE_DESCRIPTION +
+    '\n\nIMPORTANT — path namespaces differ in this session: the filesystem tools ' +
+    '(ls/read_file/write_file/edit_file/glob/grep) operate on a VIRTUAL "/" root, where a leading ' +
+    '"/" means the working directory. This shell runs in the REAL operating system and uses real ' +
+    'native paths, so a "/"-rooted path from the filesystem tools is NOT necessarily a valid path ' +
+    `for this shell. Before putting any path into a command, confirm the real working directory ` +
+    `first (run ${printWorkDirCommand()}), and prefer paths relative to the working directory over ` +
+    'absolute ones. You must also pass ' +
+    `\`${VIRTUAL_FS_SHELL_ACK_PARAM}: true\` on every call to acknowledge this.`
+  );
+}
 
 export default class GthDevToolkit extends BaseToolkit {
   tools: StructuredToolInterface[];
@@ -129,11 +194,24 @@ export default class GthDevToolkit extends BaseToolkit {
    * interrupt wiring. Omitted → historical OFF-by-default behaviour.
    */
   private readonly command: GthCommand | undefined;
+  /**
+   * True when the deep agent's deepagents `FilesystemBackend` runs in virtualMode for this run, so
+   * the fs tools address a virtual `/` root that can diverge from `run_shell_command`'s real OS
+   * paths. When set, the shell tool advertises that divergence (augmented description + the forced
+   * {@link VIRTUAL_FS_SHELL_ACK_PARAM} acknowledgement). Defaults to `false` (the lean path, whose
+   * fs tools use real paths, and any non-deep caller) so the plain shell tool is unchanged.
+   */
+  private readonly virtualFs: boolean;
 
-  constructor(commands: GthDevToolsConfig = {}, command?: GthCommand | undefined) {
+  constructor(
+    commands: GthDevToolsConfig = {},
+    command?: GthCommand | undefined,
+    options?: { virtualFs?: boolean }
+  ) {
     super();
     this.commands = commands;
     this.command = command;
+    this.virtualFs = options?.virtualFs === true;
     this.tools = this.createTools();
   }
 
@@ -442,19 +520,25 @@ export default class GthDevToolkit extends BaseToolkit {
     // agent (createDeepAgent `interruptOn`), not a parameter sanitizer — a real shell command
     // legitimately contains pipes / `$` / `;`, so validateParameterValue must NOT be applied.
     if (isShellToolEnabled(this.commands, this.command)) {
+      // In virtualMode the fs tools' `/` root diverges from this shell's real OS paths, so the
+      // shell tool warns about it (description) AND forces an explicit per-call acknowledgement
+      // (VIRTUAL_FS_SHELL_ACK_PARAM). The command runner ignores the ack flag — its only job is to
+      // make the model stop and think about the path namespace before every shell call. The plain
+      // (non-virtual) path keeps the original single-parameter tool unchanged.
+      const shellSchema = this.virtualFs
+        ? RunShellCommandVirtualArgsSchema
+        : RunShellCommandArgsSchema;
       tools.push(
         createGthTool(
-          async (args: z.infer<typeof RunShellCommandArgsSchema>): Promise<string> => {
+          async (args: z.infer<typeof shellSchema>): Promise<string> => {
             return await this.executeCommand(args.command, 'run_shell_command');
           },
           {
             name: 'run_shell_command',
-            description:
-              'Run an arbitrary shell command in the project working directory and return its ' +
-              'combined stdout/stderr and exit status. Use for any task the fixed run_* tools do ' +
-              'not cover (e.g. git, package managers, file inspection). Each call is subject to ' +
-              'human approval before it runs unless approval has been disabled.',
-            schema: RunShellCommandArgsSchema,
+            description: this.virtualFs
+              ? buildVirtualShellDescription()
+              : RUN_SHELL_COMMAND_BASE_DESCRIPTION,
+            schema: shellSchema,
           },
           'execute'
         )

--- a/packages/agent/src/tools/GthDevToolkit.ts
+++ b/packages/agent/src/tools/GthDevToolkit.ts
@@ -118,41 +118,6 @@ const RunShellCommandArgsSchema = z.object({
   command: z.string().describe('The shell command to run'),
 });
 
-/**
- * The name of the forced acknowledgement parameter added to `run_shell_command` when the deep
- * agent's filesystem tools run in virtualMode. Intentionally a long, self-describing name: the
- * model reads it on every shell call as a reminder that the fs-tool `/` root and the shell's real
- * paths are two different namespaces.
- */
-export const VIRTUAL_FS_SHELL_ACK_PARAM =
-  'i_acknowledge_that_fs_tools_are_in_virtual_mode_and_paths_could_be_different_from_shell';
-
-/**
- * virtualMode variant of {@link RunShellCommandArgsSchema}. In addition to `command` it carries a
- * FORCED acknowledgement flag ({@link VIRTUAL_FS_SHELL_ACK_PARAM}) so the model cannot call the
- * shell tool without first consciously acknowledging that a filesystem-tool `/`-rooted path is NOT
- * necessarily a valid path for this real-OS shell.
- *
- * The flag is a plain required `z.boolean()`, NOT `z.literal(true)`: a literal emits a JSON-Schema
- * `const`, which Gemini/Vertex AI's function-declaration schema dialect rejects ("Unknown name
- * `const`"), poisoning the whole request. Keeping it a bare boolean produces only `{"type":
- * "boolean"}`, which every provider accepts. The "only true is allowed" constraint is enforced at
- * RUNTIME instead (see the tool body in `createTools`), which returns a recoverable message rather
- * than aborting when the model passes anything but `true`.
- */
-const RunShellCommandVirtualArgsSchema = z.object({
-  command: z.string().describe('The shell command to run'),
-  [VIRTUAL_FS_SHELL_ACK_PARAM]: z
-    .boolean()
-    .describe(
-      'Required — you MUST pass true. By setting this to true you confirm you understand that the ' +
-        'filesystem tools (ls/read_file/write_file/edit_file/glob/grep) address a VIRTUAL "/" root ' +
-        '(a leading "/" means the working directory) which can differ from the real native paths ' +
-        'this shell uses, and that you have verified — or will verify — the real working directory ' +
-        'before relying on any path in the command. The command will NOT run unless this is true.'
-    ),
-});
-
 const TEST_PATH_PLACEHOLDER = '${testPath}';
 
 /**
@@ -186,8 +151,7 @@ function buildVirtualShellDescription(): string {
     'native paths, so a "/"-rooted path from the filesystem tools is NOT necessarily a valid path ' +
     `for this shell. Before putting any path into a command, confirm the real working directory ` +
     `first (run ${printWorkDirCommand()}), and prefer paths relative to the working directory over ` +
-    'absolute ones. You must also pass ' +
-    `\`${VIRTUAL_FS_SHELL_ACK_PARAM}: true\` on every call to acknowledge this.`
+    'absolute ones.'
   );
 }
 
@@ -203,9 +167,10 @@ export default class GthDevToolkit extends BaseToolkit {
   /**
    * True when the deep agent's deepagents `FilesystemBackend` runs in virtualMode for this run, so
    * the fs tools address a virtual `/` root that can diverge from `run_shell_command`'s real OS
-   * paths. When set, the shell tool advertises that divergence (augmented description + the forced
-   * {@link VIRTUAL_FS_SHELL_ACK_PARAM} acknowledgement). Defaults to `false` (the lean path, whose
-   * fs tools use real paths, and any non-deep caller) so the plain shell tool is unchanged.
+   * paths. When set, the shell tool's DESCRIPTION advertises that divergence (fs paths are virtual;
+   * verify the real cwd with pwd/cd; prefer relative paths). Description-only — the tool schema is
+   * identical either way. Defaults to `false` (the lean path, whose fs tools use real paths, and any
+   * non-deep caller) so the plain shell tool is unchanged.
    */
   private readonly virtualFs: boolean;
 
@@ -526,29 +491,13 @@ export default class GthDevToolkit extends BaseToolkit {
     // agent (createDeepAgent `interruptOn`), not a parameter sanitizer — a real shell command
     // legitimately contains pipes / `$` / `;`, so validateParameterValue must NOT be applied.
     if (isShellToolEnabled(this.commands, this.command)) {
-      // In virtualMode the fs tools' `/` root diverges from this shell's real OS paths, so the
-      // shell tool warns about it (description) AND forces an explicit per-call acknowledgement
-      // (VIRTUAL_FS_SHELL_ACK_PARAM). The "only true is accepted" rule is enforced HERE at runtime
-      // (not via a schema literal, which would emit a Vertex-incompatible `const`): a missing/false
-      // ack returns a recoverable message so the model retries with it set, rather than aborting.
-      // The plain (non-virtual) path keeps the original single-parameter tool unchanged.
-      const virtualFs = this.virtualFs;
-      const shellSchema = virtualFs ? RunShellCommandVirtualArgsSchema : RunShellCommandArgsSchema;
+      // In virtualMode the fs tools' `/` root diverges from this shell's real OS paths, so the shell
+      // tool's DESCRIPTION warns about it (fs paths are virtual; verify the real cwd with pwd/cd;
+      // prefer relative paths). This is description-only — the schema is identical in both modes — so
+      // there is no extra/unusual parameter to trip up provider tool-schema validation or the model.
       tools.push(
         createGthTool(
-          async (args: z.infer<typeof shellSchema>): Promise<string> => {
-            if (
-              virtualFs &&
-              (args as Record<string, unknown>)[VIRTUAL_FS_SHELL_ACK_PARAM] !== true
-            ) {
-              return (
-                `Command not run. You must set \`${VIRTUAL_FS_SHELL_ACK_PARAM}: true\` to ` +
-                'acknowledge that the filesystem tools address a virtual "/" root that can differ ' +
-                "from this shell's real paths. Confirm the real working directory first (run " +
-                `${printWorkDirCommand()}), then retry this command with the acknowledgement set ` +
-                'to true.'
-              );
-            }
+          async (args: z.infer<typeof RunShellCommandArgsSchema>): Promise<string> => {
             return await this.executeCommand(args.command, 'run_shell_command');
           },
           {
@@ -556,7 +505,7 @@ export default class GthDevToolkit extends BaseToolkit {
             description: this.virtualFs
               ? buildVirtualShellDescription()
               : RUN_SHELL_COMMAND_BASE_DESCRIPTION,
-            schema: shellSchema,
+            schema: RunShellCommandArgsSchema,
           },
           'execute'
         )

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -289,9 +289,9 @@ export interface GthConfig {
    * Transient (runtime-only) flag set by the deep agent when its deepagents `FilesystemBackend`
    * runs in virtualMode (the default now — see `shouldUseVirtualFs` in `GthDeepAgent`). It tells
    * the shared dev toolkit that the filesystem tools address a VIRTUAL `/` root that can diverge
-   * from `run_shell_command`'s real native OS paths, so the shell tool must advertise that
-   * divergence (an augmented description plus a forced acknowledgement parameter). Never set on the
-   * lean path (its fs tools use real paths, so there is no divergence) and never persisted.
+   * from `run_shell_command`'s real native OS paths, so the shell tool's description must advertise
+   * that divergence (and steer toward verifying the real cwd). Never set on the lean path (its fs
+   * tools use real paths, so there is no divergence) and never persisted.
    */
   deepFsVirtual?: boolean;
 }

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -285,6 +285,15 @@ export interface GthConfig {
    * (read/write files, run commands) rather than only chat. Never persisted to a config file.
    */
   askWriteMode?: boolean;
+  /**
+   * Transient (runtime-only) flag set by the deep agent when its deepagents `FilesystemBackend`
+   * runs in virtualMode (the default now — see `shouldUseVirtualFs` in `GthDeepAgent`). It tells
+   * the shared dev toolkit that the filesystem tools address a VIRTUAL `/` root that can diverge
+   * from `run_shell_command`'s real native OS paths, so the shell tool must advertise that
+   * divergence (an augmented description plus a forced acknowledgement parameter). Never set on the
+   * lean path (its fs tools use real paths, so there is no divergence) and never persisted.
+   */
+  deepFsVirtual?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Make the deepagents `FilesystemBackend` run in **virtualMode by default on every platform**, and compensate for the resulting fs-vs-shell path divergence by making `run_shell_command` **virtualMode-aware (description-only)**.

This keeps virtual paths as the default (uniform behaviour across Linux/macOS/Windows) and surfaces the divergence to the model through the shell tool's description and the system-prompt path-namespace notes.

## Motivation

Previously (EXT-13) the fs backend ran in **real-path mode on POSIX** so the fs tools and the shell shared one namespace, and in **virtualMode only on Windows** (EXT-16, where a `D:\…` cwd can't be a POSIX permission glob). That split meant POSIX and Windows behaved differently and was hard to reason about / stress-test.

Now virtualMode is the default everywhere. Real-path mode is retained **only** where it is genuinely needed:
- a **non-POSIX cwd** (Windows) — forced virtual anyway; and
- **`gth exec --allow-dir`** on a POSIX host — widening beyond cwd needs real absolute paths, so the EXT-13/EXT-14 real-path sandbox is kept for that case.

## What changed

**Virtual by default**
- `shouldUseVirtualFs()` now returns `true` by default; real-path only for a non-POSIX cwd (already forced virtual) or POSIX `--allow-dir` widening. Threaded consistently into the backend, permissions, and the shell tool so all three stay in lockstep.

**virtualMode-aware shell tool** (`run_shell_command`, `GthDevToolkit`) — description only
- In virtualMode the tool's **description** warns that the filesystem tools address a **virtual `/` root** which may differ from the real native paths the shell uses, tells the model to confirm the real working directory first (`pwd` on Linux/macOS, `cd` on Windows), and to prefer relative paths.
- The tool **schema is identical in both modes** (single `command` parameter). A transient `deepFsVirtual` flag carries the deep-agent's virtualMode signal through the shared resolver into `GthDevToolkit` to select the description; the **lean path is unchanged**.

**Prompt guidance**
- The EXT-22 path-namespace notes + last-word correction middleware now apply on **all platforms** (were Windows-only). `PATH_NAMESPACE_GUIDANCE` was generalised to also cover the subtler POSIX case, where the real cwd is itself `/`-rooted so a virtual `/src/x` and a real `/src/x` look identical but differ.

## History / rationale (why no schema-level "forced" param)

An earlier revision added a forced acknowledgement **parameter** to the shell tool. It proved to be a cross-provider liability and was **removed**:
- **Vertex AI** rejected the `z.literal(true)` `const` (`Unknown name "const"`).
- **Anthropic** rejected the long property key (`Property keys should match pattern '^[a-zA-Z0-9_.-]{1,64}$'`).
- It is a plausible trigger for Gemini Flash repetition loops (an unusual required field on every shell call).

Its intent — make the model aware fs paths are virtual and differ from the shell — is fully covered by the description + the system-prompt notes, so the schema now stays clean and provider-portable.

## Testing

- `pnpm run build`, `pnpm run lint`, full unit suite pass (**1282 passed, 3 skipped**).
- `GthDeepAgent.spec.ts`: POSIX default is now virtual; real-path assertions re-anchored on the `--allow-dir` case (new test), plus a test that the real-cwd note is used there.
- `GthDevToolkit.simple.spec.ts`: the schema is single-parameter in both modes; the plain description omits the warning; virtualMode augments the description (and names `pwd`/`cd`); the command still runs normally in virtualMode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJ3dzvCpWcgMZtDr1KekD7