### PR TITLE
Convert JSON Schema const to enum for Vertex AI compatibility

### DIFF
--- a/packages/agent/spec/mcpUtils.spec.ts
+++ b/packages/agent/spec/mcpUtils.spec.ts
@@ -222,6 +222,67 @@ describe('prepareMcpTools', () => {
     expect(rangeItemsSchema[0].description).toContain('number');
   });
 
+  it('should convert a string const to a single-value enum for Vertex', async () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        cloudId: {
+          properties: {
+            value: { const: 'my-cloud-id', description: 'The cloud id' },
+          },
+        },
+      },
+    } as const;
+    const tool = new DynamicStructuredTool({
+      name: 'mcp__jira__getJiraIssue',
+      description: 'Test tool',
+      schema,
+      func: async () => 'ok',
+    });
+    const { ChatGoogle } = await import('@langchain/google/node');
+    const config = {
+      llm: new ChatGoogle({ model: 'gemini-2.5-pro', vertexai: true }),
+    } as Partial<GthConfig>;
+
+    const { prepareMcpTools } = await import('#src/utils/mcpUtils.js');
+    const result = prepareMcpTools(vi.fn(), config as GthConfig, [tool]);
+
+    const valueSchema = (result?.[0].schema as any).properties.cloudId.properties.value;
+    expect(valueSchema.const).toBeUndefined();
+    expect(valueSchema.enum).toEqual(['my-cloud-id']);
+    expect(valueSchema.type).toBe('string');
+    expect(valueSchema.description).toContain('The cloud id');
+    expect(valueSchema.description).toContain('my-cloud-id');
+  });
+
+  it('should fold a non-string const into the description for Vertex', async () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        limit: { const: 50, description: 'Max results' },
+      },
+    } as const;
+    const tool = new DynamicStructuredTool({
+      name: 'mcp__jira__getJiraIssue',
+      description: 'Test tool',
+      schema,
+      func: async () => 'ok',
+    });
+    const { ChatGoogle } = await import('@langchain/google/node');
+    const config = {
+      llm: new ChatGoogle({ model: 'gemini-2.5-pro', vertexai: true }),
+    } as Partial<GthConfig>;
+
+    const { prepareMcpTools } = await import('#src/utils/mcpUtils.js');
+    const result = prepareMcpTools(vi.fn(), config as GthConfig, [tool]);
+
+    const limitSchema = (result?.[0].schema as any).properties.limit;
+    expect(limitSchema.const).toBeUndefined();
+    expect(limitSchema.enum).toBeUndefined();
+    expect(limitSchema.description).toContain('Max results');
+    expect(limitSchema.description).toContain('50');
+  });
+
   it('should convert nested union schemas in conditional branches for Vertex', async () => {
     const schema = {
       type: 'object',

--- a/packages/agent/src/utils/mcpUtils.ts
+++ b/packages/agent/src/utils/mcpUtils.ts
@@ -127,6 +127,26 @@ function replaceUnionSchemas(schema: unknown, context: ReplaceUnionSchemasContex
     };
   }
 
+  // Gemini/Vertex AI does not support the JSON Schema `const` keyword (only `enum`),
+  // so replace it. A string const becomes a single-value enum (keeps the hard
+  // constraint); any other const value is folded into the description.
+  if (schema.const !== undefined) {
+    const constValue = schema.const;
+    // The unassignment below is for purpose of taking rest of parameters except const.
+    const { const: _const, ...rest } = schema;
+    const description = mergeDescription(
+      schema.description,
+      `Must be exactly: ${JSON.stringify(constValue)}.`
+    );
+    context.log(`${context.toolName}: converted schema const at ${context.path.join('.')}`);
+    const converted: JsonInputSchema = { ...rest, description };
+    if (typeof constValue === 'string') {
+      converted.type = 'string';
+      converted.enum = [constValue];
+    }
+    return converted;
+  }
+
   let hasChanges = false;
   let updatedSchema = schema;
   const updateField = <Key extends keyof JsonInputSchema>(


### PR DESCRIPTION
## Summary
Added support for converting JSON Schema `const` keywords to `enum` format for Vertex AI/Gemini compatibility, since these models don't support the `const` keyword in tool schemas.

## Key Changes
- Added logic in `replaceUnionSchemas()` to detect and convert `const` fields in tool schemas
- String const values are converted to single-value enums (preserving the hard constraint)
- Non-string const values are folded into the field description with their exact value
- Added comprehensive test coverage for both string and non-string const conversions

## Implementation Details
- The conversion happens during schema transformation for Vertex AI models
- String consts become `enum: [value]` with `type: 'string'` to maintain strict validation
- Non-string consts (numbers, booleans, etc.) are removed and their value is appended to the description as "Must be exactly: {value}."
- The `const` keyword is stripped from the schema in all cases
- Logging is added to track when const conversions occur for debugging purposes

https://claude.ai/code/session_01GCAubtw95CW4FhSYgshixP