### PR TITLE
feat(tui): /auto-approve slash command, mid-turn invocation, status b…

### DIFF
--- a/docs/ux-guidelines.md
+++ b/docs/ux-guidelines.md
@@ -43,27 +43,42 @@ Rules:
   for caution — e.g. the **unknown-command** notice, which never forwards the text to the model and
   points the user at `/help`.
 
-## `/yolo` — session shell auto-approval (DL-4 transparency, EXT-12)
+## `/auto-approve` — session shell auto-approval (DL-4 transparency, EXT-12)
 
-`/yolo` toggles, for the current session only, whether gated `run_shell_command` calls auto-approve
-without the per-command prompt. It is **distinct from the static `shellYolo` config flag** (which
-omits the tool from `interruptOn` at agent-build time and cannot change mid-session): the runtime
-toggle lives at the approval-decision layer (`GthAgentRunner.toggleSessionYolo()` /
-`isSessionYolo()`), so the tool stays gated and the flag is consulted at the top of
-`decideToolApproval`.
+`/auto-approve` controls, for the current session only, whether gated `run_shell_command` calls
+auto-approve without the per-command prompt. `/auto-approve on` and `/auto-approve off` set it
+explicitly; a bare `/auto-approve` **toggles**. `/yolo` remains a **back-compat alias** that
+toggles. The runtime flag lives at the approval-decision layer (`GthAgentRunner.setSessionYolo()` /
+`toggleSessionYolo()` / `isSessionYolo()`), so the tool stays gated and the flag is consulted at the
+top of `decideToolApproval`.
 
-- **State-aware copy.** Like `/tools` and `/debug`, the App owns the runner flag, so it flips it and
-  commits the notice for the **resulting** state via the shared `yoloToggleNotice(yolo)` builder
-  (`yolo ON — shell commands auto-approved this session` / `yolo OFF — approvals required`). The
-  command's pure `run()` only returns `{ toggleYolo: true }`.
+- **Config seeds it, but it stays toggleable (DL-4).** In interactive `code` mode the shell tool
+  stays gated even when `devTools.shellYolo` pre-enables auto-approval: `GthAgentRunner.init` seeds
+  the session flag ON from `shellYolo`, so the user sees no prompt by default **but can still restore
+  it** with `/auto-approve off`. (Only a non-interactive `exec` / `ask --write` yolo run keeps the
+  tool ungated, since its single-shot path never drains interrupts.)
+- **State-aware copy.** Like `/tools` and `/debug`, the App owns the runner flag, so it applies the
+  requested action and commits the notice for the **resulting** state via the shared
+  `autoApproveNotice(on)` builder (`Auto-approve ON — shell commands run without asking` /
+  `Auto-approve OFF — approvals required`). The command's pure `run()` only returns
+  `{ autoApprove: 'on' | 'off' | 'toggle' }`.
 - **Tone = `warn` when ON.** Turning the approval gate off is a caution-worthy action, so the ON
   notice is yellow; OFF returns to `info`.
+- **Persistent status indicator (DL-4).** While auto-approve is ON the status bar carries an
+  unmissable yellow **`⚡ auto-approve ON`** badge (both while running and idle), so the user can
+  never lose track of the fact that shell commands run unprompted. Seeded from
+  `initialAutoApprove` so a config-enabled session shows it from the first frame.
 - **Tell the truth about the floor (DL-4).** The ON notice states that the **hardline safety floor
-  still blocks catastrophic commands** — `/yolo` only skips the approval *prompt*, it never disables
-  the unbypassable exec-time floor enforced in `GthDevToolkit.executeCommand`.
+  still blocks catastrophic commands** — auto-approve only skips the approval *prompt*, it never
+  disables the unbypassable exec-time floor enforced in `GthDevToolkit.executeCommand`.
+- **Invokable during inference (DL-9).** The prompt stays mounted while a turn streams, so
+  `/auto-approve` (and the other read-only / toggle commands marked `availableDuringRun`) can be run
+  mid-turn; idle-only commands (`/clear`, `/exit`) are refused with a friendly notice. At the
+  approval prompt itself, **`y`** turns auto-approve ON and approves the pending command in one
+  keystroke — the fastest "stop asking me" path.
 - **Session-scoped, reversible, never persisted** — nothing is written to config; toggling again
-  restores approvals. The readline interactive session mirrors the same `/yolo` toggle via
-  `displayWarning`/`displayInfo` (no `CommandNotice` there).
+  restores approvals. The readline interactive session mirrors the same `/auto-approve` (and `/yolo`)
+  commands via `displayWarning`/`displayInfo` (no `CommandNotice` there).
 
 ## `/clear` (DL-3 preserve context, DL-5 respect host)
 
@@ -96,9 +111,9 @@ Tool calls render as **collapsible panels** (`tui/components/LiveTurn.tsx`):
 - **Collapsed by default:** one summary line — caret (`▸`/`▾`) + status glyph + tool name + status
   label. Status semantics: `⋯ running` (yellow), `✓ done` (magenta), `✗ error` (red) when the
   result text looks like an error. The transcript stays readable.
-- **Expand on demand:** `/tools` toggles detail when idle; **`Ctrl+T`** toggles it mid-turn (gated
-  on `running` so the prompt's text input doesn't eat the keystroke). Expanded panels show the
-  streamed `args` and the result body.
+- **Expand on demand:** `/tools` toggles detail (it is `availableDuringRun`, so it works idle **and**
+  mid-turn); **`Ctrl+T`** is the mid-turn keyboard shortcut for the same toggle. Expanded panels show
+  the streamed `args` and the result body.
 - **Honest limitation — committed turns are frozen.** Toggling tool detail only affects the **live
   and future turns**. Committed turns live in Ink's `<Static>` and never re-fold, so an already-
   rendered turn won't retro-expand. The notice copy says exactly this ("Applies to new turns").
@@ -125,13 +140,19 @@ Tool calls render as **collapsible panels** (`tui/components/LiveTurn.tsx`):
 - **Single-line, stable status bar** (`tui/components/StatusBar.tsx`). One dim line carrying
   session context — **mode · model · turn counter · ready** — when idle; a spinner +
   `Thinking… (Esc to interrupt)` while a turn runs. Keep it to one line and free of streaming
-  progress (that belongs to the live turn) so it never flickers.
+  progress (that belongs to the live turn) so it never flickers. When session auto-approve is ON it
+  additionally carries the yellow **`⚡ auto-approve ON`** badge in both states (see `/auto-approve`).
 
 ## Keyboard model (DL-9 keyboard-first)
 
 - **`Esc`** — abort the in-flight turn (only while running).
 - **`Ctrl+C`** — exit the app. (The bare `exit` keyword and `/exit` also quit.)
 - **`Ctrl+T`** — toggle tool-call detail mid-turn (mirrors `/tools`).
+- **`o` / `s` / `a` / `y` / anything-else** at a pending shell approval — approve once / session /
+  always / turn on auto-approve-all (then approve this one) / reject (fail-closed).
+- **slash commands mid-turn** — the prompt stays mounted while a turn streams, so run-safe commands
+  (`/auto-approve`, `/tools`, `/debug`, `/help`, `/model`, …) work during inference; a plain message
+  or an idle-only command is refused with a hint until the turn finishes.
 - **`Tab`** — focus the docked debug panel when visible/idle; once focused, `Tab` cycles its views
   (`Shift+Tab` reverses), `↑`/`↓` scroll one line and `PageUp`/`PageDown` page-step (arrows are the
   documented scroll keys since Mac/compact keyboards lack dedicated `PageUp`/`PageDown` — DL-9, DL-5,

--- a/packages/agent/spec/GthDeepAgent.spec.ts
+++ b/packages/agent/spec/GthDeepAgent.spec.ts
@@ -638,7 +638,7 @@ describe('GthDeepAgent', () => {
     });
   });
 
-  it('omits interruptOn under yolo (shell enabled, shellYolo true) so the tool runs unconfirmed', async () => {
+  it('KEEPS interruptOn under yolo in interactive code mode so /auto-approve off can toggle it (EXT-12)', async () => {
     const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
     const agent = new GthDeepAgent(statusUpdate, { resolveTools: vi.fn().mockResolvedValue([]) });
     const config = makeConfig({
@@ -647,8 +647,29 @@ describe('GthDeepAgent', () => {
 
     await agent.init('code', config);
 
+    // The tool stays gated; the runner seeds its session auto-approve flag ON from shellYolo, so
+    // the user still sees no prompt by default but can restore it mid-session with /auto-approve off.
+    expect(createDeepAgentMock.mock.calls[0][0].interruptOn).toEqual({
+      run_shell_command: { allowedDecisions: ['approve', 'reject'] },
+    });
+    // It reports that config pre-enabled auto-approval (not the old "YOLO mode" ungated warning).
+    expect(statusUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('auto-approved by config')
+    );
+  });
+
+  it('omits interruptOn under yolo in non-interactive exec mode so the tool runs inline (single-shot)', async () => {
+    const { GthDeepAgent } = await import('#src/core/GthDeepAgent.js');
+    const agent = new GthDeepAgent(statusUpdate, { resolveTools: vi.fn().mockResolvedValue([]) });
+    const config = makeConfig({
+      commands: { exec: { devTools: { shell: true, shellYolo: true } } } as any,
+    });
+
+    await agent.init('exec', config);
+
+    // exec's single-shot path does not drain interrupts, so shellYolo keeps the tool ungated.
     expect(createDeepAgentMock.mock.calls[0][0].interruptOn).toBeUndefined();
-    // And it warns loudly about the bypass.
     expect(statusUpdate).toHaveBeenCalledWith(
       expect.anything(),
       expect.stringContaining('YOLO mode')

--- a/packages/agent/src/core/GthDeepAgent.ts
+++ b/packages/agent/src/core/GthDeepAgent.ts
@@ -76,9 +76,12 @@ export interface GthDeepAgentParams {
    * `__interrupt__` (a `HITLRequest`) so a consumer can approve/reject before the tool runs;
    * resume with `new Command({ resume: { decisions: [...] } })` on the same `thread_id`.
    *
-   * gsloth currently sets this only for the opt-in `run_shell_command` tool (when its
-   * `devTools.shell` is enabled and `devTools.shellYolo` is NOT). Left `undefined` otherwise —
-   * including under yolo — so no tool is gated and runs never suspend for approval.
+   * gsloth sets this for the opt-in `run_shell_command` tool whenever `devTools.shell` is
+   * enabled — including under `devTools.shellYolo` in interactive `code` mode, where the tool
+   * stays gated so the runtime `/auto-approve` flag governs it (the runner seeds that flag ON
+   * from shellYolo and auto-approves silently). It is left `undefined` only for a non-interactive
+   * yolo run (exec / ask --write), whose single-shot path does not drain interrupts, so the tool
+   * there runs inline without suspending. See `getAgentBuildParams`.
    */
   interruptOn?: Record<string, boolean | InterruptOnConfig>;
 }
@@ -530,20 +533,34 @@ export class GthDeepAgent extends GthAbstractAgent {
     // Gate the opt-in run_shell_command tool behind a per-command approval interrupt. The tool
     // is only emitted (by GthDevToolkit, via builtInToolsConfig) when its devTools.shell flag is
     // set; mirror the same per-command devTools resolution here so the interrupt is wired only
-    // when the tool actually exists. yolo (shellYolo) opts OUT of the confirmation: leave
-    // interruptOn undefined so the tool runs without suspending.
+    // when the tool actually exists.
     const devTools = this.getEffectiveDevToolsConfig();
     // EXT-12 — pass the active command so the absent-config default (shell ON in `code`)
     // is applied consistently with where the tool is actually emitted (GthDevToolkit).
     const shellEnabled = isShellToolEnabled(devTools, this.command);
-    const interruptOn =
-      shellEnabled && devTools?.shellYolo !== true
-        ? ({ run_shell_command: { allowedDecisions: ['approve', 'reject'] } } as Record<
-            string,
-            boolean | InterruptOnConfig
-          >)
-        : undefined;
-    if (interruptOn) {
+    // EXT-12 — auto-approve (shellYolo) interplay with gating:
+    //   • In interactive `code` mode we KEEP the tool gated even when shellYolo pre-enables
+    //     auto-approval, so the runner's session flag governs it and `/auto-approve off` can
+    //     restore the per-command prompt mid-session. The runner seeds that flag ON from
+    //     shellYolo (see GthAgentRunner.init), so the user still sees no prompt by default; the
+    //     interactive event/stream path drains the interrupt and auto-approves silently.
+    //   • In non-interactive modes (exec / ask --write) a single-shot run does NOT drain
+    //     interrupts, so shellYolo keeps the tool UNGATED (runs inline without suspending),
+    //     preserving prior behaviour. There is no slash-command surface there to toggle anyway.
+    const isInteractive = this.command === 'code';
+    const gateShell = shellEnabled && (devTools?.shellYolo !== true || isInteractive);
+    const interruptOn = gateShell
+      ? ({ run_shell_command: { allowedDecisions: ['approve', 'reject'] } } as Record<
+          string,
+          boolean | InterruptOnConfig
+        >)
+      : undefined;
+    if (gateShell && devTools?.shellYolo === true) {
+      this.statusUpdate(
+        StatusLevel.INFO,
+        'Shell tool (run_shell_command) auto-approved by config (shellYolo). Type /auto-approve off to require per-command approval.'
+      );
+    } else if (interruptOn) {
       this.statusUpdate(
         StatusLevel.INFO,
         'Shell tool (run_shell_command) enabled with per-command approval (interruptOn).'

--- a/packages/agent/src/modules/interactiveSessionModule.ts
+++ b/packages/agent/src/modules/interactiveSessionModule.ts
@@ -186,18 +186,38 @@ export async function createInteractiveSession(
           rl.close();
           break;
         }
-        // EXT-12 — `/yolo` toggles session-wide shell auto-approval at the approval-decision
-        // layer (the runner flag), distinct from the static `shellYolo` config. Session-scoped,
-        // reversible, never persisted; the hardline floor still blocks catastrophic commands.
-        if (lowerInput === '/yolo') {
-          const enabled = runner.toggleSessionYolo();
+        // EXT-12 — `/auto-approve` (with the `/yolo` alias) sets session-wide shell auto-approval
+        // at the approval-decision layer (the runner flag). `on`/`off` set it explicitly, no arg
+        // (or `/yolo`) toggles. Session-scoped, reversible, never persisted; the hardline floor
+        // still blocks catastrophic commands. The runner seeds this from the static `shellYolo`
+        // config, so `/auto-approve off` also turns off a config-enabled auto-approval.
+        if (
+          lowerInput === '/auto-approve' ||
+          lowerInput.startsWith('/auto-approve ') ||
+          lowerInput === '/yolo'
+        ) {
+          const arg = lowerInput.startsWith('/auto-approve ')
+            ? lowerInput.slice('/auto-approve '.length).trim()
+            : '';
+          let enabled: boolean;
+          if (arg === 'on' || arg === 'enable' || arg === 'true')
+            enabled = runner.setSessionYolo(true);
+          else if (arg === 'off' || arg === 'disable' || arg === 'false')
+            enabled = runner.setSessionYolo(false);
+          else if (arg === '' || arg === 'toggle') enabled = runner.toggleSessionYolo();
+          else {
+            displayWarning(
+              `Unknown option "${arg}". Usage: /auto-approve [on|off] (no arg toggles).`
+            );
+            continue;
+          }
           if (enabled) {
             displayWarning(
-              'yolo ON — shell commands auto-approved this session (no per-command prompt). ' +
-                'The hardline safety floor still blocks catastrophic commands. Run /yolo again to require approvals.'
+              'Auto-approve ON — shell commands run this session without the per-command prompt. ' +
+                'The hardline safety floor still blocks catastrophic commands. Run /auto-approve off to require approvals.'
             );
           } else {
-            displayInfo('yolo OFF — approvals required before each shell command.');
+            displayInfo('Auto-approve OFF — approvals required before each shell command.');
           }
           continue; // do not send the command to the model
         }

--- a/packages/app/spec/tui/App.spec.tsx
+++ b/packages/app/spec/tui/App.spec.tsx
@@ -151,7 +151,7 @@ describe('tui <App>', () => {
     unmount();
   });
 
-  it('/yolo calls agent.toggleYolo and commits the resulting-state notice (EXT-12)', async () => {
+  it('/auto-approve on|off calls agent.setAutoApprove, shows the status badge + notices (EXT-12)', async () => {
     let yolo = false;
     let turnsRun = 0;
     const agent: TuiAgent = {
@@ -159,35 +159,86 @@ describe('tui <App>', () => {
         turnsRun += 1;
         yield { type: 'text', delta: 'should not run' };
       },
-      toggleYolo() {
-        yolo = !yolo;
+      setAutoApprove(action) {
+        yolo = action === 'toggle' ? !yolo : action === 'on';
         return yolo;
       },
     };
     const { stdin, frames, lastFrame, unmount } = render(<App {...baseProps} agent={agent} />);
 
     await vi.waitFor(() => expect(lastFrame()).toContain('>'));
-    stdin.write('/yolo');
-    await vi.waitFor(() => expect(lastFrame()).toContain('/yolo'));
+    stdin.write('/auto-approve on');
+    await vi.waitFor(() => expect(lastFrame()).toContain('/auto-approve on'));
     stdin.write('\r');
 
-    // First toggle → ON notice.
+    // ON notice + persistent status-bar indicator.
     await vi.waitFor(() => {
-      expect(frames.join('\n')).toContain('yolo ON');
-      expect(frames.join('\n')).toContain('auto-approved this session');
+      expect(frames.join('\n')).toContain('Auto-approve ON');
+      expect(lastFrame()).toContain('auto-approve ON'); // status-bar badge
     });
     expect(yolo).toBe(true);
 
-    // Toggle again → OFF notice (reversible).
-    stdin.write('/yolo');
-    await vi.waitFor(() => expect(lastFrame()).toContain('/yolo'));
+    // /auto-approve off → OFF notice, badge cleared.
+    stdin.write('/auto-approve off');
+    await vi.waitFor(() => expect(lastFrame()).toContain('/auto-approve off'));
     stdin.write('\r');
-    await vi.waitFor(() => expect(frames.join('\n')).toContain('yolo OFF'));
+    await vi.waitFor(() => {
+      expect(frames.join('\n')).toContain('Auto-approve OFF');
+      expect(lastFrame()).not.toContain('auto-approve ON');
+    });
     expect(yolo).toBe(false);
 
     // The command never reaches the model.
     expect(turnsRun).toBe(0);
 
+    unmount();
+  });
+
+  it('initialAutoApprove seeds the status-bar indicator (config-enabled auto-approve)', async () => {
+    const agent = scriptedAgent([]);
+    const { lastFrame, unmount } = render(
+      <App {...baseProps} agent={agent} initialAutoApprove />
+    );
+    await vi.waitFor(() => expect(lastFrame()).toContain('auto-approve ON'));
+    unmount();
+  });
+
+  it('/auto-approve is dispatchable mid-turn; a plain message mid-turn is refused (EXT-12)', async () => {
+    let yolo = false;
+    // A turn that streams then blocks until aborted, so the prompt stays mounted (running) while
+    // we exercise mid-turn input.
+    const agent: TuiAgent = {
+      async *runTurn(_input, signal) {
+        yield { type: 'text', delta: 'working' };
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          signal.addEventListener('abort', () => resolve());
+        });
+      },
+      setAutoApprove(action) {
+        yolo = action === 'toggle' ? !yolo : action === 'on';
+        return yolo;
+      },
+    };
+    const { stdin, frames, lastFrame, unmount } = render(
+      <App {...baseProps} agent={agent} initialMessage="go" />
+    );
+
+    // While running, a plain message is refused with a hint.
+    await vi.waitFor(() => expect(lastFrame()).toContain('Thinking'));
+    stdin.write('hello there');
+    await vi.waitFor(() => expect(lastFrame()).toContain('> hello there'));
+    stdin.write('\r');
+    await vi.waitFor(() => expect(frames.join('\n')).toContain('only slash commands'));
+
+    // While running, /auto-approve on IS honoured (flag flips, badge appears next to the spinner).
+    stdin.write('/auto-approve on');
+    await vi.waitFor(() => expect(lastFrame()).toContain('> /auto-approve on'));
+    stdin.write('\r');
+    await vi.waitFor(() => expect(yolo).toBe(true));
+    await vi.waitFor(() => expect(lastFrame()).toContain('auto-approve ON'));
+
+    stdin.write(String.fromCharCode(27)); // Esc to end the run cleanly
     unmount();
   });
 

--- a/packages/app/spec/tui/ApprovalPrompt.spec.tsx
+++ b/packages/app/spec/tui/ApprovalPrompt.spec.tsx
@@ -57,6 +57,7 @@ describe('tui <ApprovalPrompt>', () => {
     expect(f).toContain('[o]nce');
     expect(f).toContain('[s]ession');
     expect(f).toContain('[a]lways');
+    expect(f).toContain('[y] auto-approve all'); // EXT-12 — turn on session auto-approve
     expect(f).toContain('[N]o');
     unmount();
   });

--- a/packages/app/spec/tui/approvalE2e.spec.tsx
+++ b/packages/app/spec/tui/approvalE2e.spec.tsx
@@ -135,6 +135,10 @@ function wireRunner(agent: GthAgentInterface, config: Partial<GthConfig>, comman
     async *runTurn(userInput, signal) {
       yield* runner.processMessagesWithEvents([new HumanMessage(userInput) as Message], signal);
     },
+    setAutoApprove(action) {
+      if (action === 'toggle') return runner.toggleSessionYolo();
+      return runner.setSessionYolo(action === 'on');
+    },
   };
   return { bridge, runner, tuiAgent, command, config };
 }
@@ -277,6 +281,67 @@ describe('EXT-11 TUI approval e2e (event-stream path)', () => {
     // The second command (a variant of the same operation) must auto-approve with NO prompt.
     await vi.waitFor(() => expect(lastFrame()).toContain('turns: 1'));
     expect(promptCount).toBe(1); // only the first command ever reached the human prompt
+
+    unmount();
+  });
+
+  it('pressing y at the approval turns on session auto-approve: this command runs and later ones skip the prompt (EXT-12)', async () => {
+    // Two suspends in one turn: the first is answered with `y` (auto-approve all), the second must
+    // then auto-approve with NO prompt because the session flag is now ON.
+    let phase = 0;
+    const agent: GthAgentInterface = {
+      async init() {},
+      async invoke() {
+        return '';
+      },
+      async stream() {
+        throw new Error('not used');
+      },
+      async *streamWithEvents(): AsyncGenerator<AgentStreamEvent> {
+        yield { type: 'text', delta: 'working' };
+      },
+      async getPendingToolInterrupts(): Promise<PendingToolInterrupt[]> {
+        phase += 1;
+        if (phase === 1) return [{ name: 'run_shell_command', args: { command: 'npm run build' } }];
+        if (phase === 2) return [{ name: 'run_shell_command', args: { command: 'npm test' } }];
+        return [];
+      },
+      async *streamWithEventsResume(): AsyncGenerator<AgentStreamEvent> {
+        yield { type: 'tool_result', id: 't', content: 'ok' };
+      },
+      async cleanup() {},
+    };
+    const { runner, bridge, tuiAgent } = wireRunner(agent, {}, 'code');
+    await runner.init('code' as never, {
+      ...FULL_CONFIG,
+      commands: { code: { devTools: { shell: { enabled: true, allowlist: false } } } },
+    } as GthConfig);
+
+    let promptCount = 0;
+    bridge.subscribe(() => {
+      promptCount += 1;
+    });
+    runner.setToolApprovalCallback((pending) => bridge.request(pending));
+
+    const { stdin, lastFrame, frames, unmount } = render(
+      <App {...baseProps} agent={tuiAgent} subscribeApproval={bridge.subscribe} initialMessage="go" />
+    );
+
+    // First command prompts; the `y` chooser is advertised and answering it enables auto-approve.
+    await vi.waitFor(() => {
+      const f = lastFrame() ?? '';
+      expect(f).toContain('npm run build');
+      expect(f).toContain('auto-approve all');
+    });
+    stdin.write('y');
+
+    // The ON notice + persistent status badge appear, and the second command NEVER prompts.
+    await vi.waitFor(() => {
+      expect(frames.join('\n')).toContain('Auto-approve ON');
+      expect(lastFrame()).toContain('turns: 1');
+    });
+    expect(promptCount).toBe(1); // only the first command reached the human prompt
+    expect(runner.isSessionYolo()).toBe(true);
 
     unmount();
   });

--- a/packages/app/spec/tui/slashCommands.spec.ts
+++ b/packages/app/spec/tui/slashCommands.spec.ts
@@ -104,26 +104,72 @@ describe('tui/slashCommands dispatchSlashCommand', () => {
     expect(result.notice?.lines[0]).toContain('single summary line');
   });
 
-  it('/yolo requests a session-yolo toggle (App owns the runner flag + state-aware notice)', async () => {
+  it('/auto-approve with no arg requests a toggle (App owns the runner flag + state-aware notice)', async () => {
     const { createCommandRegistry, dispatchSlashCommand, parseSlashCommand } =
       await import('#src/tui/slashCommands.js');
-    const result = dispatchSlashCommand(parseSlashCommand('/yolo')!, createCommandRegistry(), ctx);
-    // The command is pure: it only requests the toggle; the App flips the runner flag and commits
+    const result = dispatchSlashCommand(
+      parseSlashCommand('/auto-approve')!,
+      createCommandRegistry(),
+      ctx
+    );
+    // The command is pure: it only requests the change; the App applies the runner flag and commits
     // the notice for the resulting state (the command can't read the flag).
-    expect(result.toggleYolo).toBe(true);
+    expect(result.autoApprove).toBe('toggle');
     expect(result.notice).toBeUndefined();
     expect(result.exit).toBeUndefined();
   });
 
-  it('yoloToggleNotice copy: ON is warn-tone and mentions the hardline floor; OFF is info', async () => {
-    const { yoloToggleNotice } = await import('#src/tui/slashCommands.js');
-    const on = yoloToggleNotice(true);
-    expect(on.title).toContain('yolo ON');
+  it('/auto-approve on|off request explicit states; an unknown arg returns a usage notice', async () => {
+    const { createCommandRegistry, dispatchSlashCommand, parseSlashCommand } =
+      await import('#src/tui/slashCommands.js');
+    const registry = createCommandRegistry();
+    expect(
+      dispatchSlashCommand(parseSlashCommand('/auto-approve on')!, registry, ctx).autoApprove
+    ).toBe('on');
+    expect(
+      dispatchSlashCommand(parseSlashCommand('/auto-approve off')!, registry, ctx).autoApprove
+    ).toBe('off');
+    const bad = dispatchSlashCommand(parseSlashCommand('/auto-approve maybe')!, registry, ctx);
+    expect(bad.autoApprove).toBeUndefined();
+    expect(bad.notice?.tone).toBe('warn');
+    expect(bad.notice?.title).toContain('maybe');
+  });
+
+  it('/yolo remains a back-compat alias that requests a toggle', async () => {
+    const { createCommandRegistry, dispatchSlashCommand, parseSlashCommand } =
+      await import('#src/tui/slashCommands.js');
+    const result = dispatchSlashCommand(parseSlashCommand('/yolo')!, createCommandRegistry(), ctx);
+    expect(result.autoApprove).toBe('toggle');
+  });
+
+  it('autoApproveNotice copy: ON is warn-tone and mentions the hardline floor; OFF is info', async () => {
+    const { autoApproveNotice } = await import('#src/tui/slashCommands.js');
+    const on = autoApproveNotice(true);
+    expect(on.title).toContain('Auto-approve ON');
     expect(on.tone).toBe('warn');
     expect(on.lines.join(' ')).toContain('hardline');
-    const off = yoloToggleNotice(false);
-    expect(off.title).toContain('yolo OFF');
+    const off = autoApproveNotice(false);
+    expect(off.title).toContain('Auto-approve OFF');
     expect(off.tone).toBeUndefined();
+  });
+
+  it('dispatch during a run refuses idle-only commands but allows availableDuringRun ones', async () => {
+    const { createCommandRegistry, dispatchSlashCommand, parseSlashCommand } =
+      await import('#src/tui/slashCommands.js');
+    const registry = createCommandRegistry();
+    // /auto-approve is run-safe → still requests the change mid-turn.
+    expect(
+      dispatchSlashCommand(parseSlashCommand('/auto-approve on')!, registry, ctx, {
+        duringRun: true,
+      }).autoApprove
+    ).toBe('on');
+    // /clear is NOT run-safe → refused with a friendly warn notice, no clear requested.
+    const refused = dispatchSlashCommand(parseSlashCommand('/clear')!, registry, ctx, {
+      duringRun: true,
+    });
+    expect(refused.clearTranscript).toBeUndefined();
+    expect(refused.notice?.tone).toBe('warn');
+    expect(refused.notice?.title).toContain('not available while the agent is working');
   });
 
   it('/exit requests an app quit', async () => {

--- a/packages/app/spec/tui/tuiSessionModule.spec.tsx
+++ b/packages/app/spec/tui/tuiSessionModule.spec.tsx
@@ -24,6 +24,10 @@ vi.mock('@gaunt-sloth/core/core/GthAgentRunner.js', () => {
   GthAgentRunner.prototype.processMessagesWithEvents = vi.fn();
   GthAgentRunner.prototype.resetThread = vi.fn();
   GthAgentRunner.prototype.setToolApprovalCallback = vi.fn();
+  // EXT-12 — the session module reads the initial auto-approve state and wires setAutoApprove.
+  GthAgentRunner.prototype.isSessionYolo = vi.fn().mockReturnValue(false);
+  GthAgentRunner.prototype.toggleSessionYolo = vi.fn();
+  GthAgentRunner.prototype.setSessionYolo = vi.fn();
   return { GthAgentRunner };
 });
 

--- a/packages/app/src/tui/components/App.tsx
+++ b/packages/app/src/tui/components/App.tsx
@@ -24,11 +24,11 @@ import {
   type DebugTab,
 } from '#src/tui/components/DebugPanel.js';
 import {
+  autoApproveNotice,
   createCommandRegistry,
   dispatchSlashCommand,
   parseSlashCommand,
   toolsToggleNotice,
-  yoloToggleNotice,
 } from '#src/tui/slashCommands.js';
 import { viewportBumpSequence } from '#src/tui/terminal.js';
 
@@ -81,6 +81,13 @@ export function App(props: TuiAppProps): React.ReactElement {
   // summary lines) so the transcript stays readable; Ctrl+T flips the whole turn's detail,
   // mirroring the docked debug panel's single-key detail toggle.
   const [toolsExpanded, setToolsExpanded] = useState(false);
+  // EXT-12 — session auto-approve (shell commands run without the per-command prompt). Seeded from
+  // props (config may pre-enable it via devTools.shellYolo); the runner owns the authoritative
+  // flag, this mirror drives the persistent status-bar indicator and the state-aware notice.
+  const [autoApprove, setAutoApprove] = useState(!!props.initialAutoApprove);
+  // Mirror for the synchronous approval useInput handler, so `y` (auto-approve all) can read the
+  // current flag without a stale closure.
+  const autoApproveRef = useRef(!!props.initialAutoApprove);
   // Whether to show the post-`/clear` "history cleared" banner. Lives in the live (non-Static)
   // frame so it is reliably visible — pushing a system line right after setTranscript([]) is
   // swallowed because clearing <Static>'s items resets its internal index (TUI-C12). Hidden
@@ -209,6 +216,32 @@ export function App(props: TuiAppProps): React.ReactElement {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // EXT-12 — apply an auto-approve change (from `/auto-approve on|off`, the `/yolo` alias, or the
+  // approval prompt's `y` key). The runner owns the flag, so ask it to apply the action, mirror the
+  // landed state into local state + ref (drives the status indicator), and commit the state-aware
+  // notice. Falls back to a clear system line when the agent has no runner (fixture). Returns the
+  // landed state so the approval handler can also approve the pending command in the same keystroke.
+  const applyAutoApprove = useCallback(
+    (action: 'on' | 'off' | 'toggle'): boolean => {
+      if (!agent.setAutoApprove) {
+        push({
+          kind: 'system',
+          level: 'warning',
+          text: 'Auto-approve is unavailable in this session.',
+        });
+        return autoApproveRef.current;
+      }
+      const next = agent.setAutoApprove(action);
+      autoApproveRef.current = next;
+      setAutoApprove(next);
+      const { title, lines, tone } = autoApproveNotice(next);
+      push({ kind: 'notice', title, lines, tone: tone ?? 'info' });
+      return next;
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [agent]
+  );
+
   // Resolve the currently-shown approval (the queue head) and commit a brief notice so the
   // decision reads in the transcript (TUI-C14 notice conventions). Dequeues the head so the next
   // queued approval (if any) surfaces. Approve carries the chosen scope; reject is fail-closed.
@@ -245,10 +278,25 @@ export function App(props: TuiAppProps): React.ReactElement {
 
   const handleSubmit = useCallback(
     (value: string) => {
-      if (runningRef.current) return;
       if (!value.trim()) return;
 
-      // Legacy bare `exit` keyword still quits.
+      const running = runningRef.current;
+      const parsed = parseSlashCommand(value);
+
+      // While a turn is streaming ("during inference") the prompt stays mounted so the user can
+      // flip auto-approval or inspect state mid-turn (EXT-12). Only slash commands are honoured
+      // then — a plain message can't be sent until the turn finishes — and dispatch itself refuses
+      // any command not marked availableDuringRun. Outside a run, everything behaves as before.
+      if (running && !parsed) {
+        push({
+          kind: 'system',
+          level: 'warning',
+          text: 'The agent is working — only slash commands (e.g. /auto-approve) are available right now.',
+        });
+        return;
+      }
+
+      // Legacy bare `exit` keyword still quits (idle only — guarded above while running).
       if (isPlainExit(value)) {
         quit();
         return;
@@ -256,19 +304,23 @@ export function App(props: TuiAppProps): React.ReactElement {
 
       // A line starting with `/` is a slash command: dispatch through the registry instead
       // of sending it to the model. Unknown commands become a friendly system line.
-      const parsed = parseSlashCommand(value);
       if (parsed) {
-        const result = dispatchSlashCommand(parsed, registry, {
-          mode,
-          modelDisplayName: modelDisplayName ?? '',
-          turnCount: turnCountRef.current,
-          toolsExpanded: toolsExpandedRef.current,
-          debugVisible: debugVisibleRef.current,
-          configSummary: props.configSummary,
-          historySummary: props.historySummary,
-          insightsSummary: props.insightsSummary,
-          historySearch: props.historySearch,
-        });
+        const result = dispatchSlashCommand(
+          parsed,
+          registry,
+          {
+            mode,
+            modelDisplayName: modelDisplayName ?? '',
+            turnCount: turnCountRef.current,
+            toolsExpanded: toolsExpandedRef.current,
+            debugVisible: debugVisibleRef.current,
+            configSummary: props.configSummary,
+            historySummary: props.historySummary,
+            insightsSummary: props.insightsSummary,
+            historySearch: props.historySearch,
+          },
+          { duringRun: running }
+        );
         if (result.clearTranscript) {
           setTranscript([]);
           setSubagents(initialSubagentTree());
@@ -301,21 +353,11 @@ export function App(props: TuiAppProps): React.ReactElement {
           // toggleTools owns the notice so the copy matches the state actually applied.
           toggleTools();
         }
-        if (result.toggleYolo) {
-          // The runner owns the flag; flip it and commit the notice for the landed state. When the
-          // agent can't toggle (fixture without a runner) fall back to a clear system line rather
-          // than silently no-op. EXT-12.
-          if (agent.toggleYolo) {
-            const next = agent.toggleYolo();
-            const { title, lines, tone } = yoloToggleNotice(next);
-            push({ kind: 'notice', title, lines, tone: tone ?? 'info' });
-          } else {
-            push({
-              kind: 'system',
-              level: 'warning',
-              text: 'yolo is unavailable in this session.',
-            });
-          }
+        if (result.autoApprove) {
+          // The runner owns the flag; apply the requested action and commit the notice for the
+          // landed state via the shared helper (single-sourced with the approval prompt's y key).
+          // EXT-12.
+          applyAutoApprove(result.autoApprove);
         }
         if (result.toggleDebug) {
           setDebugVisible((v) => {
@@ -333,9 +375,9 @@ export function App(props: TuiAppProps): React.ReactElement {
             return next;
           });
         }
-        // Commit a structured notice (TUI-C14). /tools and /yolo own their notices above (the
-        // state-aware copy is committed there), so skip result.notice in those cases.
-        if (result.notice && !result.toggleTools && !result.toggleYolo) {
+        // Commit a structured notice (TUI-C14). /tools and /auto-approve own their notices above
+        // (the state-aware copy is committed there), so skip result.notice in those cases.
+        if (result.notice && !result.toggleTools && !result.autoApprove) {
           const { title, lines, tone } = result.notice;
           push({ kind: 'notice', title, lines, tone: tone ?? 'info' });
         }
@@ -349,7 +391,7 @@ export function App(props: TuiAppProps): React.ReactElement {
       void runTurn(value);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [runTurn, quit, registry, mode, modelDisplayName, toggleTools]
+    [runTurn, quit, registry, mode, modelDisplayName, toggleTools, applyAutoApprove]
   );
 
   // Keyboard handling, in priority order:
@@ -360,15 +402,21 @@ export function App(props: TuiAppProps): React.ReactElement {
   //     PageUp/PageDown page-step, m maximises, Esc unfocuses.
   useInput((input, key) => {
     // Highest priority: a pending tool approval OWNS the keyboard (EXT-9 Phase B2). While one is
-    // shown, o/s/a resolve approve with the matching scope; anything else (n, Esc, Enter, …)
-    // resolves reject — fail-closed, mirroring the readline path. We swallow the key either way
-    // so it can't fall through to abort/debug handling or get typed into the prompt.
+    // shown, o/s/a resolve approve with the matching scope; `y` turns on session auto-approve
+    // (invoking /auto-approve during inference) and approves this one; anything else (n, Esc,
+    // Enter, …) resolves reject — fail-closed, mirroring the readline path. We swallow the key
+    // either way so it can't fall through to abort/debug handling or get typed into the prompt.
     if (approvalQueueRef.current.length > 0) {
       const ch = input.toLowerCase();
       if (ch === 'o') resolveApproval('once');
       else if (ch === 's') resolveApproval('session');
       else if (ch === 'a') resolveApproval('always');
-      else resolveApproval('reject');
+      else if (ch === 'y') {
+        // Enable auto-approval for the rest of the session, then approve this pending command
+        // once so the run continues; every later gated command auto-approves silently.
+        if (!autoApproveRef.current) applyAutoApprove('on');
+        resolveApproval('once');
+      } else resolveApproval('reject');
       return;
     }
 
@@ -520,8 +568,12 @@ export function App(props: TuiAppProps): React.ReactElement {
         modelDisplayName={modelDisplayName}
         turnCount={turnCount}
         debugHint={debugVisible && !debugFocused}
+        autoApprove={autoApprove}
       />
-      {!running && !debugFocused && !pendingApproval ? (
+      {/* The prompt stays mounted while a turn streams (EXT-12), so the user can run mid-turn
+          slash commands like /auto-approve; handleSubmit + dispatch gate what's allowed then. It
+          is suspended only when the debug panel is focused or a tool approval owns the keyboard. */}
+      {!debugFocused && !pendingApproval ? (
         <PromptInput
           onSubmit={handleSubmit}
           commands={registry}

--- a/packages/app/src/tui/components/ApprovalPrompt.tsx
+++ b/packages/app/src/tui/components/ApprovalPrompt.tsx
@@ -12,8 +12,9 @@ import type { PendingToolInterrupt } from '@gaunt-sloth/core/core/types.js';
  * suspends the normal prompt, so the command can't be typed into the chat box.
  *
  * Pure/presentational: it only renders the pending command + the choices. The key handling
- * (o/s/a → approve, anything else → reject) lives in `<App>`'s `useInput`, mirroring the way
- * the debug panel's scroll keys are owned by the root component.
+ * (o/s/a → approve, y → auto-approve the rest of the session, anything else → reject) lives in
+ * `<App>`'s `useInput`, mirroring the way the debug panel's scroll keys are owned by the root
+ * component.
  */
 export function ApprovalPrompt({
   pending,
@@ -37,7 +38,9 @@ export function ApprovalPrompt({
       {verdict ? (
         <Text color="yellow">{`⚠ safety judge (${verdict.risk}): ${verdict.reason}`}</Text>
       ) : null}
-      <Text dimColor>{'Approve?  [o]nce   [s]ession   [a]lways   [N]o'}</Text>
+      <Text dimColor>
+        {'Approve?  [o]nce   [s]ession   [a]lways   [y] auto-approve all   [N]o'}
+      </Text>
     </Box>
   );
 }

--- a/packages/app/src/tui/components/StatusBar.tsx
+++ b/packages/app/src/tui/components/StatusBar.tsx
@@ -14,6 +14,7 @@ export function StatusBar({
   modelDisplayName,
   turnCount,
   debugHint,
+  autoApprove,
 }: {
   running: boolean;
   mode: string;
@@ -21,13 +22,29 @@ export function StatusBar({
   turnCount?: number;
   /** When the docked debug panel is open but unfocused, surface how to step into it. */
   debugHint?: boolean;
+  /**
+   * EXT-12 — when session auto-approve is ON, surface a persistent, unmissable indicator so the
+   * user always knows shell commands run without asking. Shown in both the running and idle
+   * states (yellow, matching the warn tone of the /auto-approve ON notice).
+   */
+  autoApprove?: boolean;
 }): React.ReactElement {
+  // A single, always-visible badge so the user can never lose track of the fact that shell
+  // commands are auto-approved (rendered next to the spinner while running, in the status line
+  // when idle). Kept terse so it fits the one-line status bar.
+  const autoApproveBadge = autoApprove ? (
+    <Text color="yellow" bold>
+      {' ⚡ auto-approve ON'}
+    </Text>
+  ) : null;
+
   if (running) {
     return (
       <Box>
         <Text color="yellow">
           <Spinner type="dots" /> Thinking… (Esc to interrupt)
         </Text>
+        {autoApproveBadge}
       </Box>
     );
   }
@@ -42,6 +59,7 @@ export function StatusBar({
   return (
     <Box>
       <Text dimColor>{segments.join('  ·  ')}</Text>
+      {autoApproveBadge}
       {debugHint ? <Text dimColor>{'  ·  Tab: focus debug panel'}</Text> : null}
     </Box>
   );

--- a/packages/app/src/tui/slashCommands.ts
+++ b/packages/app/src/tui/slashCommands.ts
@@ -170,12 +170,13 @@ export interface SlashCommandResult {
   /** When true, the component toggles tool-call panels between collapsed and expanded. */
   toggleTools?: boolean;
   /**
-   * EXT-12 — when true, the component flips the runner's session-scoped yolo flag (shell
-   * commands auto-approved this session) and commits the resulting-state notice. The command
-   * itself stays pure: it cannot read the runner's flag, so the App owns the actual toggle and
-   * the notice (mirroring how `/tools` / `/debug` defer their state-aware copy to the App).
+   * EXT-12 — a requested change to the runner's session-scoped auto-approve flag (shell commands
+   * auto-approved this session), from the `/auto-approve` command: `'on'` / `'off'` set it
+   * explicitly, `'toggle'` flips it. The command itself stays pure — it cannot read the runner's
+   * flag — so the App owns the actual apply + the resulting-state notice (mirroring how `/tools`
+   * / `/debug` defer their state-aware copy to the App).
    */
-  toggleYolo?: boolean;
+  autoApprove?: 'on' | 'off' | 'toggle';
   /** When true, the component quits the app (runs `onExit`). */
   exit?: boolean;
 }
@@ -186,6 +187,14 @@ export interface SlashCommand {
   name: string;
   /** One-line description shown by `/help`. */
   description: string;
+  /**
+   * EXT-12 — whether this command may be dispatched WHILE a turn is streaming ("during
+   * inference"). Defaults to false: most commands are idle-only. The read-only / session-toggle
+   * commands (e.g. `/auto-approve`, `/tools`, `/debug`, `/help`, `/model`) set this so the user
+   * can flip auto-approval or inspect state mid-turn without interrupting the run. Commands that
+   * mutate the transcript or thread (`/clear`) or end the session (`/exit`) stay idle-only.
+   */
+  availableDuringRun?: boolean;
   run(ctx: SlashCommandContext, args: string[]): SlashCommandResult;
 }
 
@@ -287,28 +296,42 @@ export function debugToggleNotice(visible: boolean): SlashCommandNotice {
 }
 
 /**
- * The notice for the `/yolo` toggle (EXT-12), given the RESULTING (post-toggle) state. Shared so
- * the command reports exactly the state the App applies. ON is rendered 'warn' (yellow) because it
- * disables the approval gate for the session; OFF is 'info'.
+ * The notice for the `/auto-approve` toggle (EXT-12), given the RESULTING (post-apply) state.
+ * Shared so the command reports exactly the state the App applies. ON is rendered 'warn' (yellow)
+ * because it disables the approval gate for the session; OFF is 'info'.
  */
-export function yoloToggleNotice(yolo: boolean): SlashCommandNotice {
-  return yolo
+export function autoApproveNotice(on: boolean): SlashCommandNotice {
+  return on
     ? {
-        title: 'yolo ON — shell commands auto-approved this session',
+        title: 'Auto-approve ON — shell commands run without asking',
         lines: [
           'run_shell_command will now execute WITHOUT the per-command approval prompt.',
-          'Session-scoped only (not saved); run /yolo again to require approvals.',
+          'Session-scoped only (not saved); run /auto-approve off to require approvals.',
           'The hardline safety floor still blocks catastrophic commands.',
         ],
         tone: 'warn',
       }
     : {
-        title: 'yolo OFF — approvals required',
+        title: 'Auto-approve OFF — approvals required',
         lines: [
           'run_shell_command will prompt for approval again before each command.',
-          'Run /yolo to re-enable session-wide auto-approval.',
+          'Run /auto-approve (or /auto-approve on) to re-enable session-wide auto-approval.',
         ],
       };
+}
+
+/**
+ * EXT-12 — parse the `/auto-approve` argument: no arg (or `toggle`) flips; `on`/`off` (and the
+ * friendly synonyms `enable`/`disable`, `true`/`false`) set explicitly. Returns `null` for an
+ * unrecognized argument so the command can render a usage hint instead of guessing.
+ */
+export function parseAutoApproveArg(args: string[]): 'on' | 'off' | 'toggle' | null {
+  if (args.length === 0) return 'toggle';
+  const arg = args[0].toLowerCase();
+  if (arg === 'toggle') return 'toggle';
+  if (arg === 'on' || arg === 'enable' || arg === 'true') return 'on';
+  if (arg === 'off' || arg === 'disable' || arg === 'false') return 'off';
+  return null;
 }
 
 /**
@@ -334,21 +357,48 @@ export function createCommandRegistry(): SlashCommand[] {
     {
       name: 'debug',
       description: 'Toggle the docked subagents + debug panel',
+      availableDuringRun: true,
       // State-aware: report the notice for the state the toggle will land on (the inverse of now).
       run: (ctx) => ({ toggleDebug: true, notice: debugToggleNotice(!ctx.debugVisible) }),
     },
     {
       name: 'tools',
       description: 'Toggle tool-call detail (collapsed summary ⇄ expanded args/result)',
+      availableDuringRun: true,
       // State-aware: report the notice for the state the toggle will land on (the inverse of now).
       run: (ctx) => ({ toggleTools: true, notice: toolsToggleNotice(!ctx.toolsExpanded) }),
     },
     {
+      name: 'auto-approve',
+      description:
+        'Auto-approve shell commands this session (/auto-approve on|off; no arg toggles)',
+      // Available mid-turn so the user can stop being prompted for the run's remaining tool calls
+      // (EXT-12). The App owns the runner flag, so it applies the change and commits the notice for
+      // the landed state (the command can't read the flag here).
+      availableDuringRun: true,
+      run: (_ctx, args) => {
+        const action = parseAutoApproveArg(args);
+        if (action === null) {
+          return {
+            notice: {
+              title: `Unknown option: ${args[0]}`,
+              lines: [
+                'Usage: /auto-approve [on|off] — with no argument it toggles.',
+                'When ON, shell commands run this session without the per-command prompt.',
+              ],
+              tone: 'warn',
+            },
+          };
+        }
+        return { autoApprove: action };
+      },
+    },
+    {
       name: 'yolo',
-      description: 'Toggle session-wide shell auto-approval (no per-command prompt)',
-      // State-aware: the App owns the runner flag, so it flips it and commits the notice for the
-      // landed state (the command can't read the flag here). EXT-12.
-      run: () => ({ toggleYolo: true }),
+      description: 'Alias for /auto-approve (toggles session-wide shell auto-approval)',
+      availableDuringRun: true,
+      // Back-compat alias: a bare toggle, routed through the same auto-approve apply path. EXT-12.
+      run: () => ({ autoApprove: 'toggle' }),
     },
     {
       name: 'exit',
@@ -358,6 +408,7 @@ export function createCommandRegistry(): SlashCommand[] {
     {
       name: 'mode',
       description: 'Show the current session mode',
+      availableDuringRun: true,
       run: (ctx) => ({
         notice: {
           title: `Session mode: ${ctx.mode}`,
@@ -371,6 +422,7 @@ export function createCommandRegistry(): SlashCommand[] {
     {
       name: 'config',
       description: 'Show the resolved configuration (read-only)',
+      availableDuringRun: true,
       // Read-only discovery: surface the pre-rendered, secret-free summary the App computed from
       // the resolved config. Editing lives in `gth init` / the config file, not here (GS2-1).
       run: (ctx) => ({ notice: configNotice(ctx.configSummary) }),
@@ -378,23 +430,27 @@ export function createCommandRegistry(): SlashCommand[] {
     {
       name: 'history',
       description: 'Show recent recorded sessions (local, opt-in history)',
+      availableDuringRun: true,
       // Read-only discovery, mirroring /config: render the App's fail-soft, pre-built summary.
       run: (ctx) => ({ notice: historyNotice(ctx.historySummary) }),
     },
     {
       name: 'search',
       description: 'Search recorded session history (/search <terms>)',
+      availableDuringRun: true,
       // Dynamic query, so it calls the App-injected fail-soft search provider (stubbable in tests).
       run: (ctx, args) => ({ notice: searchNotice(args, ctx.historySearch) }),
     },
     {
       name: 'insights',
       description: 'Show local analytics over recorded sessions (tokens, cost, top tools)',
+      availableDuringRun: true,
       run: (ctx) => ({ notice: insightsNotice(ctx.insightsSummary) }),
     },
     {
       name: 'model',
       description: 'Show the current model / provider',
+      availableDuringRun: true,
       run: (ctx) => ({
         notice: {
           title: `Model: ${ctx.modelDisplayName || 'unknown'}`,
@@ -420,11 +476,17 @@ export function formatHelp(registry: SlashCommand[]): SlashCommandNotice {
  * Dispatch a parsed command against a registry. Unknown commands return a friendly hint
  * rather than throwing, so the component can render it as a system line and never forward
  * the text to the model.
+ *
+ * EXT-12 — when `options.duringRun` is set (a turn is streaming), commands that are not marked
+ * {@link SlashCommand.availableDuringRun} are refused with a friendly notice rather than run,
+ * so mid-turn input can only reach the safe, non-mutating commands (`/auto-approve`, `/tools`,
+ * `/debug`, …). `/help` is always allowed.
  */
 export function dispatchSlashCommand(
   parsed: ParsedSlashCommand,
   registry: SlashCommand[],
-  ctx: SlashCommandContext
+  ctx: SlashCommandContext,
+  options: { duringRun?: boolean } = {}
 ): SlashCommandResult {
   if (parsed.name === 'help') {
     return { notice: formatHelp(registry) };
@@ -435,6 +497,18 @@ export function dispatchSlashCommand(
       notice: {
         title: `Unknown command: /${parsed.name}`,
         lines: ["That isn't a recognized slash command.", 'Run /help to see everything available.'],
+        tone: 'warn',
+      },
+    };
+  }
+  if (options.duringRun && !command.availableDuringRun) {
+    return {
+      notice: {
+        title: `/${command.name} is not available while the agent is working`,
+        lines: [
+          'Wait for the current turn to finish, then run it again.',
+          'Commands like /auto-approve, /tools and /debug do work mid-turn.',
+        ],
         tone: 'warn',
       },
     };

--- a/packages/app/src/tui/tuiSessionModule.tsx
+++ b/packages/app/src/tui/tuiSessionModule.tsx
@@ -298,9 +298,11 @@ export async function createTuiSession(
       resetThread() {
         runner.resetThread();
       },
-      // `/yolo` flips the runner's session-scoped shell auto-approval flag (EXT-12).
-      toggleYolo() {
-        return runner.toggleSessionYolo();
+      // `/auto-approve` applies the runner's session-scoped shell auto-approval flag (EXT-12):
+      // 'on'/'off' set it explicitly, 'toggle' flips it. Returns the landed state for the notice.
+      setAutoApprove(action) {
+        if (action === 'toggle') return runner.toggleSessionYolo();
+        return runner.setSessionYolo(action === 'on');
       },
     };
 
@@ -322,6 +324,7 @@ export async function createTuiSession(
         agent={tuiAgent}
         mode={sessionConfig.mode}
         modelDisplayName={config.modelDisplayName}
+        initialAutoApprove={runner.isSessionYolo()}
         configSummary={formatConfigSummary(config)}
         {...buildHistorySlashProps(config)}
         readyMessage={sessionConfig.readyMessage}

--- a/packages/app/src/tui/types.ts
+++ b/packages/app/src/tui/types.ts
@@ -32,11 +32,12 @@ export interface TuiAgent {
    */
   resetThread?(): void;
   /**
-   * EXT-12 — flip the runner's session-scoped yolo flag (shell auto-approval) and return the NEW
-   * state, so the App can render a state-aware notice. Wired to the `/yolo` slash command.
-   * Optional so the fixture agent (no runner) may omit it.
+   * EXT-12 — apply a change to the runner's session-scoped auto-approve flag (shell auto-approval)
+   * and return the NEW state, so the App can render a state-aware notice and status indicator.
+   * `'on'`/`'off'` set it explicitly, `'toggle'` flips it. Wired to the `/auto-approve` slash
+   * command. Optional so the fixture agent (no runner) may omit it.
    */
-  toggleYolo?(): boolean;
+  setAutoApprove?(action: 'on' | 'off' | 'toggle'): boolean;
 }
 
 /**
@@ -65,6 +66,13 @@ export interface TuiAppProps {
   mode: string;
   /** Model/provider display name for the status bar and `/model` (from `config.modelDisplayName`). */
   modelDisplayName?: string;
+  /**
+   * EXT-12 — initial state of the session auto-approve flag, so the status bar shows the
+   * indicator from the first frame when `devTools.shellYolo` pre-enabled it in config. The App
+   * keeps its own state after this; the session module seeds it from `runner.isSessionYolo()`.
+   * Defaults to off (undefined) — the fixture / non-shell sessions omit it.
+   */
+  initialAutoApprove?: boolean;
   /**
    * Pre-rendered, secret-free summary lines of the resolved config for the read-only `/config`
    * slash command (GS2-1). Built once by the session module via `formatConfigSummary`; omitted by

--- a/packages/core/spec/GthAgentRunner.spec.ts
+++ b/packages/core/spec/GthAgentRunner.spec.ts
@@ -505,6 +505,28 @@ describe('GthAgentRunner', () => {
       expect(runner.isSessionYolo()).toBe(false);
     });
 
+    it('setSessionYolo sets the flag explicitly (idempotent) and returns the new state (EXT-12)', async () => {
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      await runner.init('code', mockConfig);
+      expect(runner.setSessionYolo(true)).toBe(true);
+      expect(runner.setSessionYolo(true)).toBe(true); // idempotent
+      expect(runner.isSessionYolo()).toBe(true);
+      expect(runner.setSessionYolo(false)).toBe(false);
+      expect(runner.isSessionYolo()).toBe(false);
+    });
+
+    it('init seeds the auto-approve flag ON from devTools.shellYolo config (EXT-12)', async () => {
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      await runner.init('code', {
+        ...mockConfig,
+        commands: { code: { devTools: { shell: true, shellYolo: true } } },
+      } as typeof mockConfig);
+      // Config pre-enabled auto-approval, but the flag remains toggleable (/auto-approve off).
+      expect(runner.isSessionYolo()).toBe(true);
+      expect(runner.setSessionYolo(false)).toBe(false);
+      expect(runner.isSessionYolo()).toBe(false);
+    });
+
     it('auto-approves a gated shell command WITHOUT invoking the human callback when yolo is ON', async () => {
       const runner = new GthAgentRunner(statusUpdateCallback);
       mockAgent.stream.mockResolvedValue(streamOf('x'));

--- a/packages/core/src/core/GthAgentRunner.ts
+++ b/packages/core/src/core/GthAgentRunner.ts
@@ -78,13 +78,15 @@ export class GthAgentRunner {
   private lastRunStats: GthRunStats = { tools: [] };
 
   /**
-   * EXT-12 — runtime, session-scoped yolo flag toggled by the `/yolo` slash command. Distinct
-   * from the static `devTools.shellYolo` config flag (which omits the tool from `interruptOn` at
-   * agent-build time and cannot be changed mid-session). Because the tool stays gated (in
-   * `interruptOn`), this flag is consulted at the TOP of {@link decideToolApproval}: when ON, a
-   * gated `run_shell_command` is auto-approved WITHOUT prompting (yolo behaviour) for the rest of
-   * this runner's life. Never persisted; defaults OFF. It does NOT disable the hardline floor —
-   * catastrophic commands are still refused at exec time in `GthDevToolkit.executeCommand`.
+   * EXT-12 — runtime, session-scoped auto-approve flag driven by the `/auto-approve` (a.k.a.
+   * `/yolo`) slash command. Because the shell tool stays gated (in `interruptOn`) in the
+   * interactive `code` mode, this flag is consulted at the TOP of {@link decideToolApproval}:
+   * when ON, a gated `run_shell_command` is auto-approved WITHOUT prompting for the rest of this
+   * runner's life. Never persisted, but INITIALIZED at {@link init} from the static
+   * `devTools.shellYolo` config flag — so a config that pre-enables auto-approval still keeps the
+   * tool gated and therefore toggleable (`/auto-approve off` restores the per-command prompt).
+   * It does NOT disable the hardline floor — catastrophic commands are still refused at exec time
+   * in `GthDevToolkit.executeCommand`.
    */
   private sessionYolo = false;
 
@@ -130,17 +132,28 @@ export class GthAgentRunner {
   }
 
   /**
-   * EXT-12 — flip the runtime, session-scoped yolo flag (the `/yolo` slash command). When ON,
-   * gated `run_shell_command` calls auto-approve without prompting for the rest of this session;
-   * the hardline floor still applies at exec time. Returns the NEW state so the caller can render
-   * a notice. Session-scoped only — nothing is written to config.
+   * EXT-12 — flip the runtime, session-scoped auto-approve flag (the `/auto-approve` /
+   * `/yolo` slash command with no argument). When ON, gated `run_shell_command` calls
+   * auto-approve without prompting for the rest of this session; the hardline floor still applies
+   * at exec time. Returns the NEW state so the caller can render a notice. Session-scoped only —
+   * nothing is written to config.
    */
   public toggleSessionYolo(): boolean {
     this.sessionYolo = !this.sessionYolo;
     return this.sessionYolo;
   }
 
-  /** EXT-12 — current state of the runtime session-scoped yolo flag (see {@link toggleSessionYolo}). */
+  /**
+   * EXT-12 — set the session-scoped auto-approve flag explicitly (the `/auto-approve on|off`
+   * slash command). Idempotent; returns the NEW state so the caller can render a notice.
+   * Session-scoped only — nothing is written to config.
+   */
+  public setSessionYolo(on: boolean): boolean {
+    this.sessionYolo = on;
+    return this.sessionYolo;
+  }
+
+  /** EXT-12 — current state of the runtime session-scoped auto-approve flag (see {@link toggleSessionYolo}). */
   public isSessionYolo(): boolean {
     return this.sessionYolo;
   }
@@ -157,6 +170,12 @@ export class GthAgentRunner {
   ): Promise<void> {
     this.config = configIn;
     this.command = command;
+
+    // EXT-12 — seed the runtime auto-approve flag from the static `devTools.shellYolo` config so a
+    // config that pre-enables auto-approval starts ON, while the shell tool stays gated (see
+    // GthDeepAgent) and therefore remains toggleable (`/auto-approve off`). Resolved per-command,
+    // mirroring where the shell tool is actually emitted; no effect where the tool is ungated.
+    this.sessionYolo = getEffectiveDevToolsConfig(configIn, command)?.shellYolo === true;
 
     // Initialize debug logging
     initDebugLogging(configIn.debugLog ?? false);


### PR DESCRIPTION
…adge (EXT-12)

Add a first-class `/auto-approve` command for session-wide shell auto-approval, superseding the pure `/yolo` toggle (kept as a back-compat alias):

- `/auto-approve on|off` set it explicitly; a bare `/auto-approve` toggles. Parsed by a pure `parseAutoApproveArg`; unknown args show a usage notice.
- Config parity: `GthAgentRunner.init` now seeds the runtime session flag from `devTools.shellYolo`, and the shell tool stays gated (interruptOn) in interactive `code` mode even under yolo — so a config-enabled auto-approval is still toggleable with `/auto-approve off`. Non-interactive exec/ask-write keep the prior ungated behaviour (their single-shot path does not drain interrupts).
- Invoke during inference: the prompt stays mounted while a turn streams, so run-safe commands (marked `availableDuringRun`) work mid-turn; idle-only commands (`/clear`, `/exit`) and plain messages are refused with a hint. At the approval prompt, `y` turns auto-approve on and approves the pending command in one keystroke.
- Persistent, unmissable yellow `⚡ auto-approve ON` badge in the status bar (running and idle), seeded from `initialAutoApprove` so a config-enabled session shows it from the first frame.

Adds `GthAgentRunner.setSessionYolo`, replaces the `toggleYolo` / `yoloToggleNotice` TUI seam with `autoApprove` / `autoApproveNotice`, and mirrors the command in the readline session. Docs (ux-guidelines) and tests updated across core, agent and app.


Claude-Session: https://claude.ai/code/session_016vPf9yXz8ZtiBS3u4Mor9v