### PR TITLE
fix: relay MCP tool-execution errors to the model instead of aborting the turn

### DIFF
--- a/packages/agent/spec/GthDeepAgent.spec.ts
+++ b/packages/agent/spec/GthDeepAgent.spec.ts
@@ -326,6 +326,10 @@ describe('GthDeepAgent', () => {
     expect(params.middleware.map((m: { name: string }) => m.name)).toEqual([
       'GthDeepFsDenialSoftening',
       'GthDeepShellExitSoftening',
+      // Sibling softener: turns a thrown MCP ToolException (isError result) into an error
+      // ToolMessage so the model self-corrects instead of aborting the turn. Outboard of user
+      // middleware, alongside the fs/shell softeners; disjoint condition so order among them is free.
+      'GthMcpToolErrorSoftening',
       'custom-mw',
       'GthMiddlewareToolCallStatusUpdate',
       'GthMiddlewareDebugCapture',

--- a/packages/agent/src/core/GthDeepAgent.ts
+++ b/packages/agent/src/core/GthDeepAgent.ts
@@ -512,6 +512,49 @@ export class GthDeepAgent extends GthAbstractAgent {
       },
     });
 
+    // MCP tool-execution errors are spec-compliant RESULTS, not fatal faults. Per the MCP spec
+    // (2025-11-25 & draft, "Server › Tools › Error Handling"), a tool that hits an API failure, an
+    // input-validation problem, or a business-logic error (e.g. a disabled capability) returns a
+    // normal tools/call result with `isError: true`, and the CLIENT *SHOULD* hand that error to the
+    // model so it can self-correct. `@langchain/mcp-adapters` instead surfaces such a result by
+    // THROWING a ToolException at call time (its `_convertCallToolResult`). Because we install a
+    // wrapToolCall middleware, langchain's ToolNode treats any error a middleware rethrows as a fatal
+    // "middleware error" (`errorFromMiddleware && handleToolErrors !== true` → throw) and aborts the
+    // whole turn instead of relaying the error to the model — the opposite of the spec's client
+    // SHOULD. This middleware closes that gap: it catches a thrown ToolException and RETURNS it as a
+    // status:'error' ToolMessage (→ isError → ✗), so the model observes the error and can retry or
+    // explain (matching the non-stream invoke path's ToolException handling). Scope & safety: matched
+    // by name === 'ToolException' (the adapter's marker), so GraphInterrupt and every non-MCP throw
+    // fall through the final rethrow untouched. The adapter ALSO wraps a call-time AbortError into a
+    // ToolException (its `_callTool` catch-all), so we RETHROW when the run's abort signal is set —
+    // otherwise softening here would swallow user cancellation that ToolNode's own `signal?.aborted`
+    // guard normally enforces (bypassed once we handle the error in middleware). MCP connect/auth
+    // (401/403) and load failures are handled at CONNECT time (resolvers.ts throwOnLoadError +
+    // onConnectionError), not here, so they stay fatal as intended.
+    const mcpToolErrorSoftening = createMiddleware({
+      name: 'GthMcpToolErrorSoftening',
+      wrapToolCall: async (request, handler) => {
+        try {
+          return await handler(request);
+        } catch (e) {
+          if (
+            e instanceof Error &&
+            e.name === 'ToolException' &&
+            !request.runtime?.signal?.aborted
+          ) {
+            debugLog(`Softened MCP tool error into an error ToolMessage: ${e.message}`);
+            return new ToolMessage({
+              content: e.message,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              tool_call_id: (request.toolCall as any)?.id ?? '',
+              status: 'error',
+            });
+          }
+          throw e;
+        }
+      },
+    });
+
     // fsDenialSoftening first so it is the outermost wrapToolCall — it must see the throw from
     // deepagents' permission-enforcing fs tools. shellExitSoftening sits right after it (still
     // outboard of any user-configured middleware, so it always sees the raw ShellCommandFailedError
@@ -519,8 +562,16 @@ export class GthDeepAgent extends GthAbstractAgent {
     // load-bearing: they catch DISJOINT conditions (a permission-denied regex vs an
     // `instanceof ShellCommandFailedError`) and each rethrows what it doesn't recognize, so neither
     // can swallow the other. The console-bound tool-call-status middleware is NOT added here (see
-    // GthDeepAgentParams.middleware); the runner appends it.
-    const middleware = [fsDenialSoftening, shellExitSoftening, ...configuredMiddleware];
+    // GthDeepAgentParams.middleware); the runner appends it. mcpToolErrorSoftening sits alongside the
+    // other two softeners (still outboard of user middleware); it catches a DISJOINT condition
+    // (name==='ToolException') and rethrows everything else, so ordering among the three is not
+    // load-bearing.
+    const middleware = [
+      fsDenialSoftening,
+      shellExitSoftening,
+      mcpToolErrorSoftening,
+      ...configuredMiddleware,
+    ];
 
     // Map gsloth's .aiignore + filesystem mode onto deepagents permission rules. When
     // `--allow-dir` widens the sandbox, the backend runs without virtualMode, so paths are REAL

--- a/packages/core/spec/GthLangChainAgent.spec.ts
+++ b/packages/core/spec/GthLangChainAgent.spec.ts
@@ -476,6 +476,119 @@ describe('GthLangChainAgent', () => {
       });
     });
 
+    // An MCP tool that returns an `isError` result is surfaced by @langchain/mcp-adapters as a THROWN
+    // ToolException; because gth installs wrapToolCall middleware, langchain's ToolNode would treat
+    // that rethrow as a fatal "middleware error" and abort the turn. This middleware must instead
+    // convert it into a status:'error' ToolMessage so the model can self-correct (MCP spec: clients
+    // SHOULD relay tool-execution errors), while a user-cancellation (abort) still propagates.
+    describe('GthMcpToolErrorSoftening (MCP isError → model, not abort)', () => {
+      const getSoftening = () => {
+        const middleware = createAgentMock.mock.calls.at(-1)?.[0].middleware as {
+          name: string;
+          wrapToolCall?: (
+            _request: unknown,
+            _handler: (_r: unknown) => Promise<unknown>
+          ) => Promise<ToolMessage>;
+        }[];
+        return middleware.find((m) => m.name === 'GthMcpToolErrorSoftening');
+      };
+      // A ToolException as thrown by @langchain/mcp-adapters: an Error whose name is 'ToolException'.
+      const toolException = (message: string) =>
+        Object.assign(new Error(message), { name: 'ToolException' });
+
+      it('is installed right after the shell softener (outboard of user middleware)', async () => {
+        const agent = new GthLangChainAgent(statusUpdateCallback, {
+          resolveTools: vi.fn().mockResolvedValue([]),
+          resolveMiddleware: async (m) => m ?? [],
+        });
+        await agent.init('exec', mockConfig);
+
+        const middleware = createAgentMock.mock.calls.at(-1)?.[0].middleware as { name: string }[];
+        expect(middleware[0]?.name).toBe('GthLeanShellExitSoftening');
+        expect(middleware[1]?.name).toBe('GthMcpToolErrorSoftening');
+      });
+
+      it('converts a thrown ToolException into an error ToolMessage, message preserved', async () => {
+        const agent = new GthLangChainAgent(statusUpdateCallback, {
+          resolveTools: vi.fn().mockResolvedValue([]),
+          resolveMiddleware: async (m) => m ?? [],
+        });
+        await agent.init('exec', mockConfig);
+
+        const softening = getSoftening();
+        expect(softening).toBeDefined();
+        const message =
+          "MCP tool 'contract_search' on server 'unimarket' returned an error: " +
+          '{"code":"MODULE_NOT_ENABLED","message":"The CONTRACT module is not enabled."}';
+        const handler = vi.fn().mockRejectedValue(toolException(message));
+
+        const result = await softening!.wrapToolCall!(
+          { toolCall: { id: 'tc-mcp' }, runtime: { signal: undefined } },
+          handler
+        );
+        // The adapter's message (which carries the server's error body) reaches the model verbatim...
+        expect(String(result.content)).toBe(message);
+        expect(result.tool_call_id).toBe('tc-mcp');
+        // ...as a status:'error' observation (→ isError → ✗), NOT a turn-aborting throw.
+        expect(result.status).toBe('error');
+      });
+
+      it('rethrows a ToolException when the run was aborted (user cancellation is never swallowed)', async () => {
+        const agent = new GthLangChainAgent(statusUpdateCallback, {
+          resolveTools: vi.fn().mockResolvedValue([]),
+          resolveMiddleware: async (m) => m ?? [],
+        });
+        await agent.init('exec', mockConfig);
+
+        const softening = getSoftening();
+        // The adapter wraps a call-time AbortError into a ToolException; when the run's signal is
+        // aborted we must rethrow so the graph cancels rather than reporting a benign tool result.
+        const err = toolException('Error calling tool contract_search: AbortError');
+        const handler = vi.fn().mockRejectedValue(err);
+
+        await expect(
+          softening!.wrapToolCall!(
+            { toolCall: { id: 'tc-abort' }, runtime: { signal: { aborted: true } } },
+            handler
+          )
+        ).rejects.toBe(err);
+      });
+
+      it('rethrows a non-ToolException error untouched', async () => {
+        const agent = new GthLangChainAgent(statusUpdateCallback, {
+          resolveTools: vi.fn().mockResolvedValue([]),
+          resolveMiddleware: async (m) => m ?? [],
+        });
+        await agent.init('exec', mockConfig);
+
+        const softening = getSoftening();
+        const err = new Error('boom');
+        const handler = vi.fn().mockRejectedValue(err);
+
+        await expect(
+          softening!.wrapToolCall!({ toolCall: { id: 'tc-other' }, runtime: {} }, handler)
+        ).rejects.toBe(err);
+      });
+
+      it('passes a successful tool result straight through', async () => {
+        const agent = new GthLangChainAgent(statusUpdateCallback, {
+          resolveTools: vi.fn().mockResolvedValue([]),
+          resolveMiddleware: async (m) => m ?? [],
+        });
+        await agent.init('exec', mockConfig);
+
+        const softening = getSoftening();
+        const ok = new ToolMessage({ content: 'done', tool_call_id: 'tc-ok', status: 'success' });
+        const handler = vi.fn().mockResolvedValue(ok);
+
+        const result = await softening!.wrapToolCall!(
+          { toolCall: { id: 'tc-ok' }, runtime: {} },
+          handler
+        );
+        expect(result).toBe(ok);
+      });
+    });
+
     // The lean agent must install the SAME `/debug` capture middleware as the deep agent, so the
     // TUI's System-prompt / Tools / Chat-history panels populate on the (now default) lean backend.
     // Regression guard: before this, capture was deep-only and the panels stayed empty.

--- a/packages/core/src/core/GthLangChainAgent.ts
+++ b/packages/core/src/core/GthLangChainAgent.ts
@@ -169,6 +169,49 @@ export class GthLangChainAgent extends GthAbstractAgent {
       },
     });
 
+    // MCP tool-execution errors are spec-compliant RESULTS, not fatal faults. Per the MCP spec
+    // (2025-11-25 & draft, "Server › Tools › Error Handling"), a tool that hits an API failure, an
+    // input-validation problem, or a business-logic error (e.g. a disabled capability) returns a
+    // normal tools/call result with `isError: true`, and the CLIENT *SHOULD* hand that error to the
+    // model so it can self-correct. `@langchain/mcp-adapters` instead surfaces such a result by
+    // THROWING a ToolException at call time (its `_convertCallToolResult`). Because we install a
+    // wrapToolCall middleware, langchain's ToolNode treats any error a middleware rethrows as a fatal
+    // "middleware error" (`errorFromMiddleware && handleToolErrors !== true` → throw) and aborts the
+    // whole turn instead of relaying the error to the model — the opposite of the spec's client
+    // SHOULD. This middleware closes that gap: it catches a thrown ToolException and RETURNS it as a
+    // status:'error' ToolMessage (→ isError → ✗), so the model observes the error and can retry or
+    // explain (matching the non-stream invoke path's ToolException handling). Scope & safety: matched
+    // by name === 'ToolException' (the adapter's marker), so GraphInterrupt and every non-MCP throw
+    // fall through the final rethrow untouched. The adapter ALSO wraps a call-time AbortError into a
+    // ToolException (its `_callTool` catch-all), so we RETHROW when the run's abort signal is set —
+    // otherwise softening here would swallow user cancellation that ToolNode's own `signal?.aborted`
+    // guard normally enforces (bypassed once we handle the error in middleware). MCP connect/auth
+    // (401/403) and load failures are handled at CONNECT time (resolvers.ts throwOnLoadError +
+    // onConnectionError), not here, so they stay fatal as intended.
+    const mcpToolErrorSoftening = createMiddleware({
+      name: 'GthMcpToolErrorSoftening',
+      wrapToolCall: async (request, handler) => {
+        try {
+          return await handler(request);
+        } catch (e) {
+          if (
+            e instanceof Error &&
+            e.name === 'ToolException' &&
+            !request.runtime?.signal?.aborted
+          ) {
+            debugLog(`Softened MCP tool error into an error ToolMessage: ${e.message}`);
+            return new ToolMessage({
+              content: e.message,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              tool_call_id: (request.toolCall as any)?.id ?? '',
+              status: 'error',
+            });
+          }
+          throw e;
+        }
+      },
+    });
+
     // Debug-capture middleware (TUI `/debug` panel) — the lean-path sibling of GthDeepAgent's.
     // Always installed but lazy: it reads `this.debugCapture` per call, so until the TUI attaches a
     // sink it is a transparent pass-through (one extra await around the handler — the normal path
@@ -199,8 +242,14 @@ export class GthLangChainAgent extends GthAbstractAgent {
 
     // shellExitSoftening FIRST so it is the outermost wrapToolCall — it must see the raw
     // ShellCommandFailedError throw before any user-configured middleware could transform it.
+    // mcpToolErrorSoftening sits right after it, still outboard of any user-configured middleware so
+    // it sees the raw ToolException before a user wrapToolCall could transform it. Order between the
+    // two softeners is not load-bearing: they catch DISJOINT conditions (a ShellCommandFailedError
+    // vs a name==='ToolException') and each rethrows what it doesn't recognize, so neither can
+    // swallow the other.
     const middleware = [
       shellExitSoftening,
+      mcpToolErrorSoftening,
       ...configuredMiddleware,
       toolCallStatusMiddleware,
       debugCaptureMiddleware,


### PR DESCRIPTION
## Problem

When an MCP tool returns a result with `isError: true` — a **tool-execution error** such as a business-logic failure (e.g. a disabled capability), an input-validation error, or an upstream API error — `gth ask` aborts the whole agent turn with `Failed to get answer: … Stream processing failed: …` instead of letting the model see the error and respond.

This contradicts the MCP spec. Both the current GA (`2025-11-25`) and the `draft` are explicit (*Server › Tools › Error Handling*): tool-execution errors are reported *in the tool result* with `isError: true`, and

> Clients **SHOULD** provide tool execution errors to language models to enable self-correction.

## Root cause

1. `@langchain/mcp-adapters` surfaces an `isError` result by **throwing** a `ToolException` at call time (`_convertCallToolResult`: `if (result.isError) throw new ToolException(...)`).
2. gth installs a `wrapToolCall` middleware (the shell/fs softeners). When a `wrapToolCall` middleware is present, LangChain's `ToolNode` deliberately does **not** catch tool-execution errors itself — it routes anything the middleware rethrows through `#handleError(e, call, /* isMiddlewareError */ true)`.
3. There, `if (errorFromMiddleware && this.handleToolErrors !== true) throw effectiveError;` fires — `handleToolErrors` is the default *function*, not the literal `true` — so the `ToolException` is re-thrown and the turn aborts.

So the existing softeners rethrowing a non-shell/non-fs error is precisely what makes it fatal.

## Fix

Add a `GthMcpToolErrorSoftening` `wrapToolCall` middleware — a sibling of the existing `Gth*ShellExitSoftening` / `GthDeepFsDenialSoftening` softeners — to **both** backends (`GthLangChainAgent` lean + `GthDeepAgent` deep). It catches a thrown `ToolException` and **returns** it as a `status: 'error'` `ToolMessage`, so the model observes the error (→ `isError` → the ✗ affordance) and can retry or explain. This mirrors what the non-stream `invoke` path already intends for a `ToolException`, and fixes both the streaming and non-streaming paths at the graph level.

### Scope & safety
- Matched narrowly by `error.name === 'ToolException'` (the adapter's marker), so `GraphInterrupt` and every non-MCP throw fall through the existing rethrow untouched.
- The adapter also wraps a **call-time `AbortError`** into a `ToolException` (its `_callTool` catch-all). Because softening in middleware bypasses `ToolNode`'s own `if (this.signal?.aborted) throw` guard, we **rethrow when the run's abort signal is set** — user cancellation (Esc) is never swallowed.
- MCP **connection/auth** (401/403) and **load** failures are handled at *connect* time (`MultiServerMCPClient` `throwOnLoadError` + `onConnectionError`, `mcpAuthError.ts`), not on this call-time path, so they stay fatal as intended.

## Testing
- New unit tests for the lean middleware: converts a thrown `ToolException` → error `ToolMessage` (message preserved); rethrows when the abort signal is set; rethrows a non-MCP error; passes a successful result through. Updated the deep-agent middleware-order assertion.
- Full suite green (`vitest run`): 1526 passed, 0 failed.
- Verified end-to-end against a real MCP server + `gemini-3.5-flash`. Two prompts that previously aborted now relay gracefully: a `MODULE_NOT_ENABLED` tool result yields a clean "that capability isn't enabled" answer, and an input-validation error (`QUERY_TOO_SHORT`) is relayed and the model **self-corrects** by retrying with a valid query — exactly the behaviour the spec's client-SHOULD enables.

## Note for reviewers
After this change, the `ToolException`-returns-a-string branch in `GthAbstractAgent.invoke` (`Tool execution failed: …`) becomes unreachable for MCP tool errors (they're now softened upstream into a `ToolMessage`). It's left in place as a backstop for any non-MCP `ToolException` that reaches `invoke` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
