### PR TITLE
Add --no-pipe alias for --nopipe

### DIFF
--- a/packages/app/src/cli.ts
+++ b/packages/app/src/cli.ts
@@ -37,7 +37,8 @@ program
   )
   .option('--tui', 'Force the interactive Ink TUI for chat/code sessions (overrides CI auto-off)')
   .option('--no-tui', 'Force the plain readline session for chat/code (disable the TUI)')
-  .addOption(new Option('--nopipe').hideHelp(true));
+  .addOption(new Option('--nopipe').hideHelp(true))
+  .addOption(new Option('--no-pipe').hideHelp(true));
 
 const cliConfigOverrides: CommandLineConfigOverrides = {};
 

--- a/packages/core/src/utils/systemUtils.ts
+++ b/packages/core/src/utils/systemUtils.ts
@@ -291,7 +291,11 @@ export const setEntryPoint = (indexJs: string): void => {
  */
 export function readStdin(program: ProgramLike): Promise<void> {
   return new Promise((resolvePromise) => {
-    if (stdin.isTTY || program.getOptionValue('nopipe')) {
+    // `--no-pipe` is registered as a plain negated Option (cli.ts), so Commander maps it to
+    // `pipe === false` rather than `nopipe === true` — see EXT-39. Both spellings mean the same
+    // thing: skip the piped-stdin wait.
+    const nopipe = program.getOptionValue('nopipe') || program.getOptionValue('pipe') === false;
+    if (stdin.isTTY || nopipe) {
       program.parseAsync().then(() => resolvePromise());
     } else {
       // Support piping diff into gsloth


### PR DESCRIPTION
## Summary
- `--nopipe` is the existing escape hatch that skips gaunt-sloth's piped-stdin wait, but the hyphenated spelling (`--no-pipe`) is the natural first guess and wasn't recognized — surfaced while building a takahe custom tool that shells out to a nested `gth` (EXT-39).
- Registers `--no-pipe` as a second Option. Commander auto-negates any `--no-*` flag, mapping it to `getOptionValue('pipe') === false` rather than a `nopipe`-named attribute, so `readStdin()` now checks both signals.
- Longer-term angle tracked in EXT-39 (takahe graph): consider a better name, or fixing this at the root so nested/scripted `gth` invocations never need an escape hatch (e.g. `GthCustomToolkit.executeCommand` closing the spawned child's stdin instead of leaving an open, never-fed pipe).

## Test plan
- [x] `pnpm run build` (core/agent/review/app) — clean
- [x] `pnpm run unit` — 1526 passed, 3 skipped (pre-existing, unrelated win32 skips)
- [x] `pnpm run lint` — clean
- [x] Manual: `node packages/app/cli.js --nopipe ask --help` and `--no-pipe ask --help` both skip the stdin wait; `echo hi | node packages/app/cli.js ask --help` (no flag) still shows `reading STDIN` and proceeds normally, confirming piping is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)