### PR TITLE
fix(app): exit non-zero when a gth ask run fails

### DIFF
--- a/packages/app/spec/askCommand.spec.ts
+++ b/packages/app/spec/askCommand.spec.ts
@@ -80,10 +80,13 @@ vi.mock('#src/utils/llmUtils.js', async () => {
   };
 });
 vi.mock('@gaunt-sloth/core/runtime/singleShot.js', () => singleShotModule);
-vi.mock('#src/utils/systemUtils.js', () => ({
+const systemUtilsMock = {
   getStringFromStdin: vi.fn().mockReturnValue(''),
-}));
+  setExitCode: vi.fn(),
+};
+vi.mock('#src/utils/systemUtils.js', () => systemUtilsMock);
 const consoleUtilsMock = {
+  displayError: vi.fn(),
   displayWarning: vi.fn(),
 };
 vi.mock('@gaunt-sloth/core/utils/consoleUtils.js', () => consoleUtilsMock);
@@ -103,6 +106,9 @@ describe('askCommand', () => {
     // Set up config mock
     configMock.initConfig.mockResolvedValue(mockConfig);
     configMock.createDefaultConfig.mockReturnValue(mockConfig);
+
+    // A run succeeds unless a test says otherwise.
+    runSingleShot.mockResolvedValue(true);
 
     // Mock the util functions
     fileUtilsMock.readMultipleFilesFromProjectDir.mockImplementation((files: string[]) => {
@@ -143,6 +149,28 @@ describe('askCommand', () => {
     );
     // ask defaults to the lean backend; an explicit agent.backend would override it.
     expect(resolveAgentFactoryMock.resolveAgentFactory).toHaveBeenCalledWith(mockConfig, 'lean');
+    expect(systemUtilsMock.setExitCode).not.toHaveBeenCalled();
+  });
+
+  it('sets a non-zero exit code when the run fails', async () => {
+    runSingleShot.mockResolvedValue(false);
+    const { askCommand } = await import('#src/commands/askCommand.js');
+    const program = new Command();
+    askCommand(program, {});
+    await program.parseAsync(['na', 'na', 'ask', 'test message']);
+
+    expect(systemUtilsMock.setExitCode).toHaveBeenCalledWith(1);
+  });
+
+  it('sets a non-zero exit code when the run throws', async () => {
+    runSingleShot.mockRejectedValue(new Error('boom'));
+    const { askCommand } = await import('#src/commands/askCommand.js');
+    const program = new Command();
+    askCommand(program, {});
+    await program.parseAsync(['na', 'na', 'ask', 'test message']);
+
+    expect(consoleUtilsMock.displayError).toHaveBeenCalled();
+    expect(systemUtilsMock.setExitCode).toHaveBeenCalledWith(1);
   });
 
   it('Should call runSingleShot with message and file content', async () => {

--- a/packages/app/src/commands/askCommand.ts
+++ b/packages/app/src/commands/askCommand.ts
@@ -2,8 +2,8 @@ import { Command } from 'commander';
 import { CommandLineConfigOverrides, initConfig } from '@gaunt-sloth/core/config.js';
 import type { GthConfig } from '@gaunt-sloth/core/config.js';
 import { getAskSystemPrompt } from '#src/commands/commandIntrospection.js';
-import { getStringFromStdin } from '@gaunt-sloth/core/utils/systemUtils.js';
-import { displayWarning } from '@gaunt-sloth/core/utils/consoleUtils.js';
+import { getStringFromStdin, setExitCode } from '@gaunt-sloth/core/utils/systemUtils.js';
+import { displayError, displayWarning } from '@gaunt-sloth/core/utils/consoleUtils.js';
 import { wrapContent } from '@gaunt-sloth/core/utils/llmUtils.js';
 
 import { readMultipleFilesFromProjectDir } from '@gaunt-sloth/core/utils/fileUtils.js';
@@ -99,15 +99,25 @@ export function askCommand(
       const { createResolvers } = await import('@gaunt-sloth/agent/resolvers.js');
       const { resolveAgentFactory } =
         await import('@gaunt-sloth/agent/core/resolveAgentFactory.js');
-      await runSingleShot(
-        'ASK',
-        getAskSystemPrompt(config),
-        content.join('\n'),
-        config,
-        createResolvers(),
-        'ask',
-        // ask defaults to the lean backend; an explicit config.agent.backend overrides it.
-        resolveAgentFactory(config, 'lean')
-      );
+      let ok = false;
+      try {
+        ok = await runSingleShot(
+          'ASK',
+          getAskSystemPrompt(config),
+          content.join('\n'),
+          config,
+          createResolvers(),
+          'ask',
+          // ask defaults to the lean backend; an explicit config.agent.backend overrides it.
+          resolveAgentFactory(config, 'lean')
+        );
+      } catch (error) {
+        displayError(error instanceof Error ? error.message : String(error));
+        ok = false;
+      }
+
+      if (!ok) {
+        setExitCode(1);
+      }
     });
 }


### PR DESCRIPTION
## What

`gth ask` awaited `runSingleShot()` and discarded its boolean result, so the command exited **0 even when the agent turn aborted** (tool error, refusal, transport failure). Automation could not distinguish a crashed turn from a successful one without grepping stdout for failure strings.

This handles the result the way the sibling `exec` command already does: capture the return value and `setExitCode(1)` when it is falsy, wrapping the call in `try`/`catch` so a thrown error also yields exit 1 with a displayed message rather than an unhandled rejection.

## Why

Reported in #405 (§2), where it is one of the reporter's two stated top priorities — his eval harness currently detects aborted turns by regex-matching failure strings on stdout.

`exec` was already correct, so this is a parity fix rather than a design change. `ask` and `exec` are the only two commands calling `runSingleShot`, so this closes the class.

Related to #405 (§2). Deliberately **not** a closing keyword — #405 is a broad batch/eval feature request that this does not close.

## Scope

Strictly the exit code. The richer run-status taxonomy also discussed in #405 §2 (distinguishing *clean answer · tool-error abort · refusal · transport/auth error · timeout*) is **not** in this PR.

The pre-flight "at least one of file, stdin, or message" argument validation is unchanged and still throws.

## Tests

Three tests added to `packages/app/spec/askCommand.spec.ts`, mirroring the existing `execCommand.spec.ts` coverage: no exit code set on success, exit 1 when the run resolves false, exit 1 when the run throws.

Verified the two failure tests genuinely exercise the fix — against the pre-fix source they fail (`2 failed | 12 passed`), with it they pass (`14 passed`). Full suite: `1528 passed | 3 skipped`, lint and prettier clean.
