### PR TITLE
batch: gth batch core matrix runtime (BATCH-1)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -96,6 +96,7 @@ export default defineConfig([
   pkgSourceConfig('core'),
   pkgSourceConfig('agent'),
   pkgSourceConfig('review'),
+  pkgSourceConfig('batch'),
   pkgSourceConfig('app'),
   // Test TypeScript files with separate project reference
   {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "//1": "Root workspace package — not published. Publishable packages live in packages/* (gaunt-sloth [dir: app], agent, core, review).",
+  "//1": "Root workspace package — not published. Publishable packages live in packages/* (gaunt-sloth [dir: app], agent, batch, core, review).",
   "name": "gaunt-sloth-workspace",
   "version": "0.0.0",
   "private": true,
@@ -18,7 +18,7 @@
   "packageManager": "pnpm@11.3.0",
   "scripts": {
     "clean": "pnpm -r --if-present run clean",
-    "build": "pnpm --filter @gaunt-sloth/core run build && pnpm --filter @gaunt-sloth/agent run build && pnpm --filter @gaunt-sloth/review run build && pnpm --filter gaunt-sloth run build",
+    "build": "pnpm --filter @gaunt-sloth/core run build && pnpm --filter @gaunt-sloth/agent run build && pnpm --filter @gaunt-sloth/review run build && pnpm --filter @gaunt-sloth/batch run build && pnpm --filter gaunt-sloth run build",
     "unit": "vitest run",
     "test": "pnpm run build && vitest run",
     "it": "pnpm run build && node it.js",
@@ -35,7 +35,7 @@
     "release:tag": "./tag-packages.sh",
     "release:publish": "./publish-all.sh"
   },
-  "//2": "Root workspace package — not published, holds dev dependencies. Publishable packages live in packages/* (gaunt-sloth [dir: app], agent, core, review).",
+  "//2": "Root workspace package — not published, holds dev dependencies. Publishable packages live in packages/* (gaunt-sloth [dir: app], agent, batch, core, review).",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/express": "^5.0.6",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@gaunt-sloth/agent": "workspace:*",
+    "@gaunt-sloth/batch": "workspace:*",
     "@gaunt-sloth/core": "workspace:*",
     "@gaunt-sloth/review": "workspace:*",
     "@langchain/anthropic": "^1.5.1",

--- a/packages/app/spec/batchCommand.spec.ts
+++ b/packages/app/spec/batchCommand.spec.ts
@@ -96,9 +96,27 @@ describe('batchCommand', () => {
 
     outputDir = mkdtempSync(join(tmpdir(), 'gth-batch-command-'));
 
-    configMock.initConfig.mockResolvedValue({ ...mockConfig, llm: { ...mockConfig.llm } });
+    // Mirrors the real initConfig({ model }) -> tryJsonConfig -> processJsonConfig path (BATCH-1
+    // fix): a `model` override in the call produces a genuinely fresh config/llm for that model,
+    // rather than the base config being cloned/mutated. Reacting to the override here is what lets
+    // the fan-out tests below prove `initConfig` is actually invoked per distinct model.
+    configMock.initConfig.mockImplementation(async (overrides: { model?: string } = {}) => {
+      if (overrides.model) {
+        return {
+          ...mockConfig,
+          llm: { invoke: vi.fn(), model: overrides.model },
+          modelDisplayName: overrides.model,
+        };
+      }
+      return { ...mockConfig, llm: { ...mockConfig.llm } };
+    });
     runSingleShot.mockResolvedValue(true);
-    resolversMock.createResolvers.mockReturnValue({ resolveTools: vi.fn(), cleanupTools: vi.fn() });
+    // A fresh resolvers object (with its own spy-able cleanupTools) per call, so per-cell
+    // cleanup tests below can tell which cell's resolvers were cleaned up.
+    resolversMock.createResolvers.mockImplementation(() => ({
+      resolveTools: vi.fn(),
+      cleanupTools: vi.fn(),
+    }));
 
     prompt.readExecPrompt.mockReturnValue('EXEC MODE PROMPT');
     prompt.buildSystemMessages.mockReturnValue([{ content: 'EXEC SYSTEM PROMPT' }]);
@@ -171,9 +189,53 @@ describe('batchCommand', () => {
     expect(runSingleShot).toHaveBeenCalledTimes(2);
     const modelsPassed = runSingleShot.mock.calls.map((call) => call[3].llm.model).sort();
     expect(modelsPassed).toEqual(['model-a', 'model-b']);
+    // BATCH-1 fix: each distinct model must be built via a genuinely fresh initConfig() call
+    // (which threads through tryJsonConfig -> processJsonConfig, the provider-factory path),
+    // not by cloning the base config's llm instance.
+    expect(configMock.initConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'model-a' })
+    );
+    expect(configMock.initConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'model-b' })
+    );
     // The original base config's llm instance must be untouched (no shared-instance mutation).
     expect(mockConfig.llm.model).toEqual('base-model');
   });
+
+  it(
+    'regression (BATCH-1 finding 1): builds one fresh config per DISTINCT model, not per cell — ' +
+      'a matrix that reuses a model across several --over rows must not re-run initConfig for it',
+    async () => {
+      const { batchCommand } = await import('#src/commands/batchCommand.js');
+      const program = new Command();
+      batchCommand(program, {});
+      // 2 models x 2 rows = 4 cells, but only 2 DISTINCT models.
+      await program.parseAsync([
+        'na',
+        'na',
+        'batch',
+        'script.md',
+        '--models',
+        'model-a,model-b',
+        '--over',
+        'cases.csv',
+        '-o',
+        outputDir,
+      ]);
+
+      expect(runSingleShot).toHaveBeenCalledTimes(4);
+      // 1 base initConfig() call (command entry) + 1 per distinct model = 3, not 1 + 4.
+      expect(configMock.initConfig).toHaveBeenCalledTimes(3);
+
+      const cellsForModelA = runSingleShot.mock.calls.filter(
+        (call) => call[3].llm.model === 'model-a'
+      );
+      expect(cellsForModelA).toHaveLength(2);
+      // Both cells sharing `model-a` must have been handed the SAME fresh llm instance (the
+      // cache hit), not two independently-built ones.
+      expect(cellsForModelA[0][3].llm).toBe(cellsForModelA[1][3].llm);
+    }
+  );
 
   it('fans out over --over rows, interpolating {{field}} into the script content', async () => {
     const { batchCommand } = await import('#src/commands/batchCommand.js');
@@ -221,6 +283,85 @@ describe('batchCommand', () => {
       expect.stringContaining('1 cell(s) failed')
     );
   });
+
+  it(
+    'regression (BATCH-1 finding 2): calls cleanupTools() exactly once per cell on the success ' +
+      'path — createResolvers() must not be passed inline and discarded',
+    async () => {
+      const { batchCommand } = await import('#src/commands/batchCommand.js');
+      const program = new Command();
+      batchCommand(program, {});
+      await program.parseAsync([
+        'na',
+        'na',
+        'batch',
+        'script.md',
+        '--models',
+        'model-a,model-b',
+        '-o',
+        outputDir,
+      ]);
+
+      expect(resolversMock.createResolvers).toHaveBeenCalledTimes(2);
+      const resolversInstances = resolversMock.createResolvers.mock.results.map((r) => r.value);
+      for (const resolvers of resolversInstances) {
+        expect(resolvers.cleanupTools).toHaveBeenCalledTimes(1);
+      }
+    }
+  );
+
+  it(
+    'regression (BATCH-1 finding 2): calls cleanupTools() exactly once per cell even when the ' +
+      'cell throws',
+    async () => {
+      runSingleShot.mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce(true);
+      const { batchCommand } = await import('#src/commands/batchCommand.js');
+      const program = new Command();
+      batchCommand(program, {});
+      await program.parseAsync([
+        'na',
+        'na',
+        'batch',
+        'script.md',
+        '--models',
+        'model-a,model-b',
+        '-o',
+        outputDir,
+      ]);
+
+      expect(resolversMock.createResolvers).toHaveBeenCalledTimes(2);
+      const resolversInstances = resolversMock.createResolvers.mock.results.map((r) => r.value);
+      for (const resolvers of resolversInstances) {
+        expect(resolvers.cleanupTools).toHaveBeenCalledTimes(1);
+      }
+
+      const resultsJson = JSON.parse(readFileSync(join(outputDir, 'results.json'), 'utf8'));
+      expect(resultsJson.passed).toBe(1);
+      expect(resultsJson.failed).toBe(1);
+    }
+  );
+
+  it(
+    'regression (BATCH-1 finding 2): a cleanupTools() failure never masks or overrides the ' +
+      "cell's real result (exit-code contract must survive a cleanup failure too)",
+    async () => {
+      resolversMock.createResolvers.mockImplementation(() => ({
+        resolveTools: vi.fn(),
+        cleanupTools: vi.fn().mockRejectedValue(new Error('cleanup boom')),
+      }));
+      const { batchCommand } = await import('#src/commands/batchCommand.js');
+      const program = new Command();
+      batchCommand(program, {});
+      await program.parseAsync(['na', 'na', 'batch', 'script.md', '-o', outputDir]);
+
+      const resultsJson = JSON.parse(readFileSync(join(outputDir, 'results.json'), 'utf8'));
+      expect(resultsJson.passed).toBe(1); // real cell result preserved despite cleanup failure
+      expect(systemUtilsMock.setExitCode).not.toHaveBeenCalled();
+      expect(consoleUtilsMock.displayWarning).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to clean up tools')
+      );
+    }
+  );
 
   it('propagates a malformed --over file as a harness-level throw (uncaught by the action)', async () => {
     fileUtilsMock.readFileFromProjectDir.mockImplementation(() => '');

--- a/packages/app/spec/batchCommand.spec.ts
+++ b/packages/app/spec/batchCommand.spec.ts
@@ -1,0 +1,276 @@
+import { Command } from 'commander';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// Make randomUUID deterministic across this spec (used by wrapContent block ids)
+vi.mock('node:crypto', async () => {
+  const actual = await vi.importActual<typeof import('node:crypto')>('node:crypto');
+  return {
+    ...actual,
+    randomUUID: () => '12345678-aaaa-bbbb-cccc-1234567890ab',
+  };
+});
+
+const resolversMock = {
+  createResolvers: vi.fn(),
+};
+vi.mock('@gaunt-sloth/agent/resolvers.js', () => resolversMock);
+
+const resolvedFactory = vi.fn();
+const resolveAgentFactoryMock = {
+  resolveAgentFactory: vi.fn(() => resolvedFactory),
+};
+vi.mock('@gaunt-sloth/agent/core/resolveAgentFactory.js', () => resolveAgentFactoryMock);
+
+const runSingleShot = vi.fn();
+vi.mock('@gaunt-sloth/core/runtime/singleShot.js', () => ({ runSingleShot }));
+
+const prompt = {
+  readExecPrompt: vi.fn(),
+  readBackstory: vi.fn(),
+  readGuidelines: vi.fn(),
+  readSystemPrompt: vi.fn(),
+  buildSystemMessages: vi.fn(),
+};
+vi.mock('@gaunt-sloth/core/utils/llmUtils.js', async () => {
+  const actual = await vi.importActual<typeof import('@gaunt-sloth/core/utils/llmUtils.js')>(
+    '@gaunt-sloth/core/utils/llmUtils.js'
+  );
+  return {
+    ...actual,
+    readExecPrompt: prompt.readExecPrompt,
+    readBackstory: prompt.readBackstory,
+    readGuidelines: prompt.readGuidelines,
+    readSystemPrompt: prompt.readSystemPrompt,
+    buildSystemMessages: prompt.buildSystemMessages,
+  };
+});
+
+// A safe (non-root, cleaned-up-per-test) stand-in for where getGslothFilePath would place a
+// default-named report/dir in a real project.
+const defaultOutputRoot = join(tmpdir(), 'gth-batch-command-default-output');
+
+const fileUtilsMock = {
+  readMultipleFilesFromProjectDir: vi.fn(),
+  readFileFromProjectDir: vi.fn(),
+  getGslothFilePath: vi.fn((name: string) => join(defaultOutputRoot, name)),
+  fileSafeLocalDate: vi.fn(() => '2026-07-18_00-00-00'),
+};
+vi.mock('@gaunt-sloth/core/utils/fileUtils.js', () => fileUtilsMock);
+
+const consoleUtilsMock = {
+  displaySuccess: vi.fn(),
+  displayWarning: vi.fn(),
+  displayError: vi.fn(),
+};
+vi.mock('@gaunt-sloth/core/utils/consoleUtils.js', () => consoleUtilsMock);
+
+const systemUtilsMock = {
+  setExitCode: vi.fn(),
+};
+vi.mock('@gaunt-sloth/core/utils/systemUtils.js', () => systemUtilsMock);
+
+const mockConfig = {
+  llm: { invoke: vi.fn(), model: 'base-model' },
+  projectGuidelines: '.gsloth.guidelines.md',
+  streamOutput: true,
+  writeOutputToFile: true,
+  canInterruptInferenceWithEsc: true,
+  commands: { exec: { filesystem: 'all' } },
+};
+
+const configMock = {
+  initConfig: vi.fn(),
+};
+vi.mock('@gaunt-sloth/core/config.js', () => configMock);
+
+describe('batchCommand', () => {
+  let outputDir: string;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    outputDir = mkdtempSync(join(tmpdir(), 'gth-batch-command-'));
+
+    configMock.initConfig.mockResolvedValue({ ...mockConfig, llm: { ...mockConfig.llm } });
+    runSingleShot.mockResolvedValue(true);
+    resolversMock.createResolvers.mockReturnValue({ resolveTools: vi.fn(), cleanupTools: vi.fn() });
+
+    prompt.readExecPrompt.mockReturnValue('EXEC MODE PROMPT');
+    prompt.buildSystemMessages.mockReturnValue([{ content: 'EXEC SYSTEM PROMPT' }]);
+
+    fileUtilsMock.readMultipleFilesFromProjectDir.mockImplementation((files: string | string[]) => {
+      const list = Array.isArray(files) ? files : [files];
+      if (list.includes('script.md')) return 'Greet {{name}}.';
+      return '';
+    });
+    fileUtilsMock.readFileFromProjectDir.mockImplementation((file: string) => {
+      if (file === 'cases.csv') return 'name\nalice\nbob\n';
+      throw new Error(`unexpected file read: ${file}`);
+    });
+  });
+
+  afterEach(() => {
+    rmSync(outputDir, { recursive: true, force: true });
+    rmSync(defaultOutputRoot, { recursive: true, force: true });
+  });
+
+  it('registers the batch command with description', async () => {
+    const { batchCommand } = await import('#src/commands/batchCommand.js');
+    const program = new Command();
+    batchCommand(program, {});
+    expect(program.commands[0].name()).toEqual('batch');
+    expect(program.commands[0].description()).toContain('matrix');
+  });
+
+  it('runs a single cell (no --models, no --over) through runSingleShot with the exec command', async () => {
+    const { batchCommand } = await import('#src/commands/batchCommand.js');
+    const program = new Command();
+    batchCommand(program, {});
+    await program.parseAsync(['na', 'na', 'batch', 'script.md', '-o', outputDir]);
+
+    expect(runSingleShot).toHaveBeenCalledTimes(1);
+    const [source, preamble, content, config, , command, agentFactory] =
+      runSingleShot.mock.calls[0];
+    expect(source).toEqual('BATCH-cell-0-0');
+    expect(preamble).toEqual('EXEC SYSTEM PROMPT');
+    expect(content).toContain('Greet {{name}}.');
+    expect(command).toEqual('exec');
+    expect(config.writeOutputToFile).toBe(false);
+    expect(config.canInterruptInferenceWithEsc).toBe(false);
+    expect(agentFactory).toBe(resolvedFactory);
+
+    const resultsJson = JSON.parse(readFileSync(join(outputDir, 'results.json'), 'utf8'));
+    expect(resultsJson).toEqual({
+      total: 1,
+      passed: 1,
+      failed: 0,
+      cells: [{ id: 'cell-0-0', model: undefined, inputIndex: 0, ok: true, retries: 0 }],
+    });
+  });
+
+  it('fans out over --models, one runSingleShot call per model with an overridden llm.model', async () => {
+    const { batchCommand } = await import('#src/commands/batchCommand.js');
+    const program = new Command();
+    batchCommand(program, {});
+    await program.parseAsync([
+      'na',
+      'na',
+      'batch',
+      'script.md',
+      '--models',
+      'model-a,model-b',
+      '-o',
+      outputDir,
+    ]);
+
+    expect(runSingleShot).toHaveBeenCalledTimes(2);
+    const modelsPassed = runSingleShot.mock.calls.map((call) => call[3].llm.model).sort();
+    expect(modelsPassed).toEqual(['model-a', 'model-b']);
+    // The original base config's llm instance must be untouched (no shared-instance mutation).
+    expect(mockConfig.llm.model).toEqual('base-model');
+  });
+
+  it('fans out over --over rows, interpolating {{field}} into the script content', async () => {
+    const { batchCommand } = await import('#src/commands/batchCommand.js');
+    const program = new Command();
+    batchCommand(program, {});
+    await program.parseAsync([
+      'na',
+      'na',
+      'batch',
+      'script.md',
+      '--over',
+      'cases.csv',
+      '-o',
+      outputDir,
+    ]);
+
+    expect(runSingleShot).toHaveBeenCalledTimes(2);
+    const contents = runSingleShot.mock.calls.map((call) => call[2]).sort();
+    expect(contents[0]).toContain('Greet alice.');
+    expect(contents[1]).toContain('Greet bob.');
+  });
+
+  it('never sets a non-zero exit code just because a cell failed (exit-code contract)', async () => {
+    runSingleShot.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    const { batchCommand } = await import('#src/commands/batchCommand.js');
+    const program = new Command();
+    batchCommand(program, {});
+    await program.parseAsync([
+      'na',
+      'na',
+      'batch',
+      'script.md',
+      '--models',
+      'model-a,model-b',
+      '-o',
+      outputDir,
+    ]);
+
+    expect(systemUtilsMock.setExitCode).not.toHaveBeenCalled();
+    const resultsJson = JSON.parse(readFileSync(join(outputDir, 'results.json'), 'utf8'));
+    expect(resultsJson.total).toBe(2);
+    expect(resultsJson.passed).toBe(1);
+    expect(resultsJson.failed).toBe(1);
+    expect(consoleUtilsMock.displayWarning).toHaveBeenCalledWith(
+      expect.stringContaining('1 cell(s) failed')
+    );
+  });
+
+  it('propagates a malformed --over file as a harness-level throw (uncaught by the action)', async () => {
+    fileUtilsMock.readFileFromProjectDir.mockImplementation(() => '');
+    const { batchCommand } = await import('#src/commands/batchCommand.js');
+    const program = new Command();
+    batchCommand(program, {});
+
+    await expect(
+      program.parseAsync(['na', 'na', 'batch', 'script.md', '--over', 'cases.csv', '-o', outputDir])
+    ).rejects.toThrow(/empty CSV/);
+
+    expect(runSingleShot).not.toHaveBeenCalled();
+  });
+
+  it('respects -j/--concurrency and --retry pass-through to the runner', async () => {
+    // Every cell fails once then succeeds on retry — proves --retry actually reruns cells.
+    let calls = 0;
+    runSingleShot.mockImplementation(async () => {
+      calls++;
+      return calls > 1;
+    });
+    const { batchCommand } = await import('#src/commands/batchCommand.js');
+    const program = new Command();
+    batchCommand(program, {});
+    await program.parseAsync([
+      'na',
+      'na',
+      'batch',
+      'script.md',
+      '-j',
+      '2',
+      '--retry',
+      '1',
+      '-o',
+      outputDir,
+    ]);
+
+    expect(calls).toBe(2); // 1 failed attempt + 1 retry
+    const resultsJson = JSON.parse(readFileSync(join(outputDir, 'results.json'), 'utf8'));
+    expect(resultsJson.passed).toBe(1);
+  });
+
+  it('uses the default timestamped output dir when -o is omitted', async () => {
+    const { batchCommand, defaultBatchOutputDir } = await import('#src/commands/batchCommand.js');
+    const program = new Command();
+    batchCommand(program, {});
+    await program.parseAsync(['na', 'na', 'batch', 'script.md']);
+
+    expect(consoleUtilsMock.displaySuccess).toHaveBeenCalledWith(
+      expect.stringContaining(defaultBatchOutputDir())
+    );
+  });
+});

--- a/packages/app/src/cli.ts
+++ b/packages/app/src/cli.ts
@@ -1,6 +1,7 @@
 import { Command, Option } from 'commander';
 import { askCommand } from '#src/commands/askCommand.js';
 import { execCommand } from '#src/commands/execCommand.js';
+import { batchCommand } from '#src/commands/batchCommand.js';
 import { initCommand } from '#src/commands/initCommand.js';
 import { reviewCommand } from '#src/commands/reviewCommand.js';
 import { prCommand } from '#src/commands/prCommand.js';
@@ -83,6 +84,7 @@ reviewCommand(program, cliConfigOverrides);
 prCommand(program, cliConfigOverrides);
 askCommand(program, cliConfigOverrides);
 execCommand(program, cliConfigOverrides);
+batchCommand(program, cliConfigOverrides);
 chatCommand(program, cliConfigOverrides);
 codeCommand(program, cliConfigOverrides);
 apiCommand(program, cliConfigOverrides);

--- a/packages/app/src/commands/batchCommand.ts
+++ b/packages/app/src/commands/batchCommand.ts
@@ -1,0 +1,225 @@
+import { Command } from 'commander';
+import { CommandLineConfigOverrides, initConfig } from '@gaunt-sloth/core/config.js';
+import type { GthConfig } from '@gaunt-sloth/core/config.js';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { getExecSystemPrompt } from '#src/commands/commandIntrospection.js';
+import { displaySuccess, displayWarning } from '@gaunt-sloth/core/utils/consoleUtils.js';
+import { wrapContent } from '@gaunt-sloth/core/utils/llmUtils.js';
+import {
+  fileSafeLocalDate,
+  getGslothFilePath,
+  readFileFromProjectDir,
+  readMultipleFilesFromProjectDir,
+} from '@gaunt-sloth/core/utils/fileUtils.js';
+import type { RunCellFn } from '@gaunt-sloth/batch';
+
+interface BatchCommandOptions {
+  /** `--over <path.csv|path.jsonl>` — the input axis: one matrix cell per row/record. */
+  over?: string;
+  /** `--models a,b,c` — the model axis: one matrix cell per model. */
+  models?: string;
+  /** `-j/--concurrency <n>` — max in-flight cells. */
+  concurrency?: number;
+  /** `--retry <n>` — retries on a failed cell. */
+  retry?: number;
+  /** `-o/--output <dir>` — where structured per-cell + summary output is written. */
+  output?: string;
+}
+
+/**
+ * Give a cell its own model, without mutating the config's shared `BaseChatModel` instance.
+ *
+ * `GthConfig.llm` is already an *instantiated* LangChain chat model by the time `initConfig()`
+ * returns it (not a raw `{ type, model, apiKey, ... }` config record) — the resolved shape
+ * `buildExecConfig`'s temperature knob also works against, via `execConfig.llm.temperature = …`.
+ * That in-place mutation is safe for `exec` (one config, one run), but batch can run several
+ * models concurrently, so mutating one shared instance's `.model` would race between cells.
+ *
+ * Instead this clones the instance with `Object.create` + `getOwnPropertyDescriptors` — same
+ * prototype (so `.invoke`/`.bindTools`/etc. keep working), independent own properties (so setting
+ * `.model` on the clone can't be seen by any other cell) — and sets `.model` on the clone. Every
+ * built-in provider (`packages/core/src/providers/*.ts`) constructs its LangChain class with a
+ * plain `model: llmConfig.model` field (not a private `#` field), which is the same assumption the
+ * temperature knob already relies on; this has not been verified against a live provider call in
+ * this task (see the task report's known-gaps section) — a class that keeps model-selection state
+ * behind a private field or a lazily-built client would silently keep calling the original model.
+ * Providers that don't expose `model` at all are left untouched rather than guessed at.
+ */
+function cloneLlmWithModel(llm: BaseChatModel, model: string): BaseChatModel {
+  if (!('model' in llm)) {
+    return llm;
+  }
+  const clone = Object.create(
+    Object.getPrototypeOf(llm) as object,
+    Object.getOwnPropertyDescriptors(llm)
+  ) as BaseChatModel;
+  (clone as unknown as { model: string }).model = model;
+  return clone;
+}
+
+/**
+ * Build the injectable {@link RunCellFn} that adapts the shared single-shot runtime
+ * (`runSingleShot`) to one matrix cell. Isolated in its own function so each cell run gets a fresh
+ * `createResolvers()` (its own MCP client instance) — matching batch's "N isolated model calls"
+ * contract (docs/batch-mechanism-vs-judgment.md) rather than sharing one resolver/client across
+ * concurrent cells.
+ *
+ * batch writes its own structured JSON per cell (via `writeBatchOutput`), so `writeOutputToFile` is
+ * forced off for every cell run — the per-cell `.md` report `runSingleShot` would otherwise write is
+ * not wanted here. `command: 'exec'` is passed through so cells get the same near-deterministic,
+ * exec-mode prompt as `gth exec` — batch is "exec over a matrix" (docs/batch-eval-cli-surface.md).
+ */
+async function buildProductionRunCell(baseConfig: GthConfig, preamble: string): Promise<RunCellFn> {
+  const { runSingleShot } = await import('@gaunt-sloth/core/runtime/singleShot.js');
+  const { createResolvers } = await import('@gaunt-sloth/agent/resolvers.js');
+  const { resolveAgentFactory } = await import('@gaunt-sloth/agent/core/resolveAgentFactory.js');
+
+  return async (cell) => {
+    const cellConfig: GthConfig = {
+      ...baseConfig,
+      canInterruptInferenceWithEsc: false,
+      writeOutputToFile: false,
+      ...(cell.model
+        ? { llm: cloneLlmWithModel(baseConfig.llm, cell.model), modelDisplayName: cell.model }
+        : {}),
+    };
+    const content = wrapContent(cell.content, 'script', 'prompt-executable script', true);
+
+    try {
+      const ok = await runSingleShot(
+        `BATCH-${cell.id}`,
+        preamble,
+        content,
+        cellConfig,
+        createResolvers(),
+        'exec',
+        // batch defaults to the lean backend, same as exec; an explicit config.agent.backend wins.
+        resolveAgentFactory(cellConfig, 'lean')
+      );
+      return { ok };
+    } catch (error) {
+      // runSingleShot itself is documented to never throw for a normal LLM/tool failure (it
+      // returns false instead); this guards the rare case of a genuinely unexpected exception so
+      // one bad cell can never take the whole batch run down.
+      return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  };
+}
+
+/** Parse `--models a,b,c` into a trimmed, non-empty list; `undefined` when the flag is absent. */
+export function parseModelsOption(models: string | undefined): string[] | undefined {
+  if (!models) return undefined;
+  const list = models
+    .split(',')
+    .map((m) => m.trim())
+    .filter((m) => m.length > 0);
+  return list.length > 0 ? list : undefined;
+}
+
+/** Default output dir when `-o/--output` is omitted: a timestamped dir next to other gth reports. */
+export function defaultBatchOutputDir(): string {
+  return getGslothFilePath(`gth_${fileSafeLocalDate()}_BATCH`);
+}
+
+function parseIntOption(value: string): number {
+  const parsed = parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Expected an integer, got "${value}"`);
+  }
+  return parsed;
+}
+
+/**
+ * Adds the `batch` command to the program.
+ *
+ * `gth batch <script.md> --over <csv|jsonl> [--models a,b,c] [-j 8] [--retry 2] [-o out/]` — runs a
+ * prompt-executable over a matrix (models × content-bound inputs), the way `exec` runs one. See
+ * docs/batch-eval-cli-surface.md and docs/batch-mechanism-vs-judgment.md for the design.
+ *
+ * Exit-code contract (BATCH-1, decisive design point): `gth batch` exits 0 iff the cells *ran* —
+ * it never fails because a cell's answer was poor quality (that is `gth eval`'s job, BATCH-2, not
+ * this command). Only a harness-level error (a malformed `--over` file, a missing script, etc.)
+ * sets a non-zero exit code; a per-cell failure is recorded in that cell's structured JSON output,
+ * never reflected in the process exit code.
+ *
+ * @param program - The commander program
+ * @param commandLineConfigOverrides - command line config overrides
+ */
+export function batchCommand(
+  program: Command,
+  commandLineConfigOverrides: CommandLineConfigOverrides
+): void {
+  program
+    .command('batch')
+    .description(
+      'Run a markdown prompt-executable over a matrix of models and/or content-bound inputs ' +
+        '("xargs for prompts"). Exits 0 iff the cells ran — a poor answer is not a harness failure.'
+    )
+    .argument('<script>', 'Path to the .md prompt-executable script to run over the matrix')
+    .option(
+      '--over <path>',
+      'CSV or JSONL file whose rows/records bind into the script content via {{field}} ' +
+        'placeholders — one matrix cell per row (content binding only; a glob-of-files path ' +
+        'binding is not supported by this command)'
+    )
+    .option(
+      '--models <list>',
+      'Comma-separated list of models to fan out over (omit to use the configured model, no fan-out)'
+    )
+    .option('-j, --concurrency <n>', 'Max in-flight cells', parseIntOption)
+    .option(
+      '--retry <n>',
+      'Retry a failed cell up to n times (default: 0, no retry)',
+      parseIntOption
+    )
+    .option(
+      '-o, --output <dir>',
+      'Directory to write structured per-cell JSON + results.json summary to ' +
+        '(default: a timestamped dir alongside other gth reports)'
+    )
+    .action(async (script: string, options: BatchCommandOptions) => {
+      const config = await initConfig(commandLineConfigOverrides);
+
+      // Specific `.js` subpaths (not the bare package root) — matches the house convention
+      // (`@gaunt-sloth/core/runtime/singleShot.js`, `@gaunt-sloth/review/utils/fileUtils.js`, …)
+      // that vitest's workspace-import resolver (vitest.config.ts) recognizes and resolves
+      // straight to source, so specs exercise live `packages/batch/src` rather than a `dist/`
+      // build that could go stale between an edit and a test run.
+      const { buildMatrix } = await import('@gaunt-sloth/batch/matrix.js');
+      const { parseOverFile } = await import('@gaunt-sloth/batch/parseOver.js');
+      const { runBatchMatrix } = await import('@gaunt-sloth/batch/BatchRunner.js');
+      const { writeBatchOutput } = await import('@gaunt-sloth/batch/output.js');
+
+      const scriptContent = readMultipleFilesFromProjectDir([script]);
+      const models = parseModelsOption(options.models);
+      const rows = options.over
+        ? parseOverFile(options.over, readFileFromProjectDir(options.over))
+        : undefined;
+
+      const cells = buildMatrix(scriptContent, models, rows);
+
+      const preamble = getExecSystemPrompt(config);
+      const runCell = await buildProductionRunCell(config, preamble);
+
+      const results = await runBatchMatrix(cells, {
+        runCell,
+        concurrency: options.concurrency,
+        retry: options.retry,
+      });
+
+      const outputDir = options.output ?? defaultBatchOutputDir();
+      const summary = writeBatchOutput(outputDir, results);
+
+      displaySuccess(
+        `Batch complete: ${summary.passed}/${summary.total} cell(s) passed. ` +
+          `Results written to ${outputDir}`
+      );
+      if (summary.failed > 0) {
+        // Visible, but deliberately does NOT set a non-zero exit code — see the exit-code
+        // contract above. A poor/failed cell is `eval`'s business, not batch's.
+        displayWarning(
+          `${summary.failed} cell(s) failed — see ${outputDir}/results.json for details.`
+        );
+      }
+    });
+}

--- a/packages/app/src/commands/batchCommand.ts
+++ b/packages/app/src/commands/batchCommand.ts
@@ -1,7 +1,6 @@
 import { Command } from 'commander';
 import { CommandLineConfigOverrides, initConfig } from '@gaunt-sloth/core/config.js';
 import type { GthConfig } from '@gaunt-sloth/core/config.js';
-import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { getExecSystemPrompt } from '#src/commands/commandIntrospection.js';
 import { displaySuccess, displayWarning } from '@gaunt-sloth/core/utils/consoleUtils.js';
 import { wrapContent } from '@gaunt-sloth/core/utils/llmUtils.js';
@@ -27,34 +26,45 @@ interface BatchCommandOptions {
 }
 
 /**
- * Give a cell its own model, without mutating the config's shared `BaseChatModel` instance.
+ * Build a per-model {@link GthConfig} cache: one genuinely fresh `initConfig()` call (fresh `.llm`
+ * instance included) per DISTINCT `--models` value, not one per cell — a 20-cell matrix over 3
+ * models must only construct 3 model instances.
  *
- * `GthConfig.llm` is already an *instantiated* LangChain chat model by the time `initConfig()`
- * returns it (not a raw `{ type, model, apiKey, ... }` config record) — the resolved shape
- * `buildExecConfig`'s temperature knob also works against, via `execConfig.llm.temperature = …`.
- * That in-place mutation is safe for `exec` (one config, one run), but batch can run several
- * models concurrently, so mutating one shared instance's `.model` would race between cells.
+ * BATCH-1 fix (CI review finding, critical): the previous approach gave a cell its own model by
+ * structurally cloning the shared `GthConfig.llm` instance (`Object.create` +
+ * `getOwnPropertyDescriptors`) and setting `.model` on the clone. That never runs the original
+ * class's constructor, so it never gets that instance's private (`#field`) slots — any LangChain
+ * chat-model class whose methods touch a `#privateField` internally (not just the public `model`
+ * field the old code checked for) would throw `TypeError: Cannot read private member from an
+ * object whose class did not declare it` the moment such a method ran on the clone. That risk is
+ * not provider-specific and cannot be ruled out by inspecting today's installed provider
+ * versions. This replaces cloning with construction: each distinct model gets a real
+ * `initConfig({ ...overrides, model })` call, which threads the override through
+ * `tryJsonConfig` (`packages/core/src/config/loader.ts`) so the provider's own
+ * `processJsonConfig()` builds the instance from scratch — the same supported path every other
+ * model comes from, correct for any provider.
  *
- * Instead this clones the instance with `Object.create` + `getOwnPropertyDescriptors` — same
- * prototype (so `.invoke`/`.bindTools`/etc. keep working), independent own properties (so setting
- * `.model` on the clone can't be seen by any other cell) — and sets `.model` on the clone. Every
- * built-in provider (`packages/core/src/providers/*.ts`) constructs its LangChain class with a
- * plain `model: llmConfig.model` field (not a private `#` field), which is the same assumption the
- * temperature knob already relies on; this has not been verified against a live provider call in
- * this task (see the task report's known-gaps section) — a class that keeps model-selection state
- * behind a private field or a lazily-built client would silently keep calling the original model.
- * Providers that don't expose `model` at all are left untouched rather than guessed at.
+ * Cached by `Promise<GthConfig>` (not just by resolved value) so concurrent cells requesting the
+ * same not-yet-resolved model share one in-flight `initConfig()` call instead of racing to build
+ * the model twice.
  */
-function cloneLlmWithModel(llm: BaseChatModel, model: string): BaseChatModel {
-  if (!('model' in llm)) {
-    return llm;
-  }
-  const clone = Object.create(
-    Object.getPrototypeOf(llm) as object,
-    Object.getOwnPropertyDescriptors(llm)
-  ) as BaseChatModel;
-  (clone as unknown as { model: string }).model = model;
-  return clone;
+function createCellConfigResolver(
+  baseConfig: GthConfig,
+  commandLineConfigOverrides: CommandLineConfigOverrides
+): (model: string | undefined) => Promise<GthConfig> {
+  const configForModel = new Map<string, Promise<GthConfig>>();
+
+  return (model: string | undefined): Promise<GthConfig> => {
+    if (!model) {
+      return Promise.resolve(baseConfig);
+    }
+    let cached = configForModel.get(model);
+    if (!cached) {
+      cached = initConfig({ ...commandLineConfigOverrides, model });
+      configForModel.set(model, cached);
+    }
+    return cached;
+  };
 }
 
 /**
@@ -69,29 +79,39 @@ function cloneLlmWithModel(llm: BaseChatModel, model: string): BaseChatModel {
  * not wanted here. `command: 'exec'` is passed through so cells get the same near-deterministic,
  * exec-mode prompt as `gth exec` — batch is "exec over a matrix" (docs/batch-eval-cli-surface.md).
  */
-async function buildProductionRunCell(baseConfig: GthConfig, preamble: string): Promise<RunCellFn> {
+async function buildProductionRunCell(
+  baseConfig: GthConfig,
+  preamble: string,
+  commandLineConfigOverrides: CommandLineConfigOverrides
+): Promise<RunCellFn> {
   const { runSingleShot } = await import('@gaunt-sloth/core/runtime/singleShot.js');
   const { createResolvers } = await import('@gaunt-sloth/agent/resolvers.js');
   const { resolveAgentFactory } = await import('@gaunt-sloth/agent/core/resolveAgentFactory.js');
 
+  const resolveCellModelConfig = createCellConfigResolver(baseConfig, commandLineConfigOverrides);
+
   return async (cell) => {
+    const modelConfig = await resolveCellModelConfig(cell.model);
     const cellConfig: GthConfig = {
-      ...baseConfig,
+      ...modelConfig,
       canInterruptInferenceWithEsc: false,
       writeOutputToFile: false,
-      ...(cell.model
-        ? { llm: cloneLlmWithModel(baseConfig.llm, cell.model), modelDisplayName: cell.model }
-        : {}),
     };
     const content = wrapContent(cell.content, 'script', 'prompt-executable script', true);
 
+    // BATCH-1 fix (CI review finding, critical): keep the resolvers reference and clean it up
+    // unconditionally (success or failure) — the previous code passed `createResolvers()` inline
+    // into `runSingleShot(...)` and discarded the reference, so `cleanupTools()` (which tears
+    // down any MCP-server-backed tools/processes the cell's resolution opened) was never called —
+    // an orphaned-process leak, one per cell.
+    const resolvers = createResolvers();
     try {
       const ok = await runSingleShot(
         `BATCH-${cell.id}`,
         preamble,
         content,
         cellConfig,
-        createResolvers(),
+        resolvers,
         'exec',
         // batch defaults to the lean backend, same as exec; an explicit config.agent.backend wins.
         resolveAgentFactory(cellConfig, 'lean')
@@ -102,6 +122,17 @@ async function buildProductionRunCell(baseConfig: GthConfig, preamble: string): 
       // returns false instead); this guards the rare case of a genuinely unexpected exception so
       // one bad cell can never take the whole batch run down.
       return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    } finally {
+      try {
+        await resolvers.cleanupTools?.();
+      } catch (cleanupError) {
+        // A cleanup failure must never mask or override the cell's real result (already returned
+        // above) — surface it as a warning only.
+        displayWarning(
+          `Failed to clean up tools for cell ${cell.id}: ` +
+            `${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
+        );
+      }
     }
   };
 }
@@ -199,7 +230,7 @@ export function batchCommand(
       const cells = buildMatrix(scriptContent, models, rows);
 
       const preamble = getExecSystemPrompt(config);
-      const runCell = await buildProductionRunCell(config, preamble);
+      const runCell = await buildProductionRunCell(config, preamble, commandLineConfigOverrides);
 
       const results = await runBatchMatrix(cells, {
         runCell,

--- a/packages/batch/package.json
+++ b/packages/batch/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@gaunt-sloth/batch",
+  "version": "2.0.0-alpha.19",
+  "description": "Batch matrix runtime for Gaunt Sloth (BATCH-1): run a prompt-executable over a matrix of models and/or content-bound inputs",
+  "license": "MIT",
+  "author": "Andrew Kondratev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pukeko-robotics/gaunt-sloth.git",
+    "directory": "packages/batch"
+  },
+  "bugs": {
+    "url": "https://github.com/pukeko-robotics/gaunt-sloth/issues"
+  },
+  "homepage": "https://github.com/pukeko-robotics/gaunt-sloth/tree/main/packages/batch#readme",
+  "keywords": [
+    "ai",
+    "agent",
+    "llm",
+    "batch",
+    "cli"
+  ],
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./*.js": "./dist/*.js"
+  },
+  "imports": {
+    "#src/*.js": "./dist/*.js"
+  },
+  "dependencies": {
+    "@gaunt-sloth/core": "workspace:*"
+  },
+  "files": [
+    "./dist/*"
+  ],
+  "scripts": {
+    "build": "tsc"
+  },
+  "publishConfig": {
+    "tag": "alpha"
+  }
+}

--- a/packages/batch/spec/BatchRunner.spec.ts
+++ b/packages/batch/spec/BatchRunner.spec.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import type { CellRunOutcome, MatrixCell, RunCellFn } from '#src/types.js';
+
+function makeCells(n: number): MatrixCell[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `cell-0-${i}`,
+    modelIndex: 0,
+    inputIndex: i,
+    content: `content-${i}`,
+  }));
+}
+
+/** A deferred promise, for precise control over when a fake cell "finishes". */
+function deferred<T>(): { promise: Promise<T>; resolve: (_value: T) => void } {
+  let resolve!: (_value: T) => void;
+  const promise = new Promise<T>((res) => (resolve = res));
+  return { promise, resolve };
+}
+
+describe('runBatchMatrix', () => {
+  it('runs every cell and preserves matrix order in the results', async () => {
+    const { runBatchMatrix } = await import('#src/BatchRunner.js');
+    const cells = makeCells(5);
+    const runCell: RunCellFn = async (cell) => ({ ok: true, answer: cell.content });
+
+    const results = await runBatchMatrix(cells, { runCell });
+
+    expect(results).toHaveLength(5);
+    expect(results.map((r) => r.id)).toEqual([
+      'cell-0-0',
+      'cell-0-1',
+      'cell-0-2',
+      'cell-0-3',
+      'cell-0-4',
+    ]);
+    expect(results.every((r) => r.ok)).toBe(true);
+  });
+
+  it('never lets more than `concurrency` cells run at once', async () => {
+    const { runBatchMatrix } = await import('#src/BatchRunner.js');
+    const cells = makeCells(6);
+    const gates = cells.map(() => deferred<void>());
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const runCell: RunCellFn = async (cell) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      const index = Number(cell.id.split('-').pop());
+      await gates[index].promise;
+      inFlight--;
+      return { ok: true };
+    };
+
+    const runPromise = runBatchMatrix(cells, { runCell, concurrency: 2 });
+
+    // Let the first wave of workers start.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(inFlight).toBeLessThanOrEqual(2);
+    expect(maxInFlight).toBeLessThanOrEqual(2);
+
+    // Release all gates so the run can complete.
+    gates.forEach((g) => g.resolve());
+    await runPromise;
+
+    expect(maxInFlight).toBe(2);
+  });
+
+  it('defaults concurrency to DEFAULT_CONCURRENCY and normalizes invalid values', async () => {
+    const { runBatchMatrix } = await import('#src/BatchRunner.js');
+    const { DEFAULT_CONCURRENCY } = await import('#src/types.js');
+    const cells = makeCells(DEFAULT_CONCURRENCY + 3);
+    let maxInFlight = 0;
+    let inFlight = 0;
+    const runCell: RunCellFn = async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return { ok: true };
+    };
+
+    // concurrency: 0 is invalid (< 1) and must fall back to the default rather than deadlocking.
+    await runBatchMatrix(cells, { runCell, concurrency: 0 });
+    expect(maxInFlight).toBe(DEFAULT_CONCURRENCY);
+  });
+
+  it('retries a failing cell up to `retry` times, then records failure', async () => {
+    const { runBatchMatrix } = await import('#src/BatchRunner.js');
+    const cells = makeCells(1);
+    let calls = 0;
+    const runCell: RunCellFn = async () => {
+      calls++;
+      return { ok: false, error: `attempt ${calls} failed` };
+    };
+
+    const results = await runBatchMatrix(cells, { runCell, retry: 2 });
+
+    expect(calls).toBe(3); // 1 initial + 2 retries
+    expect(results[0].ok).toBe(false);
+    expect(results[0].retries).toBe(2);
+    expect(results[0].error).toEqual('attempt 3 failed');
+  });
+
+  it('stops retrying as soon as a cell succeeds', async () => {
+    const { runBatchMatrix } = await import('#src/BatchRunner.js');
+    const cells = makeCells(1);
+    let calls = 0;
+    const runCell: RunCellFn = async (): Promise<CellRunOutcome> => {
+      calls++;
+      return calls < 3 ? { ok: false, error: 'transient' } : { ok: true, answer: 'finally' };
+    };
+
+    const results = await runBatchMatrix(cells, { runCell, retry: 5 });
+
+    expect(calls).toBe(3);
+    expect(results[0].ok).toBe(true);
+    expect(results[0].retries).toBe(2);
+    expect(results[0].answer).toEqual('finally');
+  });
+
+  it('does not retry by default (retry: 0)', async () => {
+    const { runBatchMatrix } = await import('#src/BatchRunner.js');
+    const cells = makeCells(1);
+    let calls = 0;
+    const runCell: RunCellFn = async () => {
+      calls++;
+      return { ok: false };
+    };
+
+    const results = await runBatchMatrix(cells, { runCell });
+
+    expect(calls).toBe(1);
+    expect(results[0].retries).toBe(0);
+  });
+
+  it('catches a thrown error from runCell and records it as a failure instead of propagating', async () => {
+    const { runBatchMatrix } = await import('#src/BatchRunner.js');
+    const cells = makeCells(1);
+    const runCell: RunCellFn = async () => {
+      throw new Error('boom');
+    };
+
+    const results = await runBatchMatrix(cells, { runCell, retry: 1 });
+
+    expect(results[0].ok).toBe(false);
+    expect(results[0].error).toEqual('boom');
+    expect(results[0].retries).toBe(1);
+  });
+
+  it('one failing cell does not affect the outcome of other cells (isolation)', async () => {
+    const { runBatchMatrix } = await import('#src/BatchRunner.js');
+    const cells = makeCells(4);
+    const runCell: RunCellFn = async (cell) => {
+      if (cell.inputIndex === 2) throw new Error('cell 2 exploded');
+      return { ok: true };
+    };
+
+    const results = await runBatchMatrix(cells, { runCell });
+
+    expect(results[2].ok).toBe(false);
+    expect(results.filter((r) => r.ok)).toHaveLength(3);
+  });
+
+  it('records a per-cell durationMs >= 0', async () => {
+    const { runBatchMatrix } = await import('#src/BatchRunner.js');
+    const cells = makeCells(1);
+    const runCell: RunCellFn = async () => ({ ok: true });
+
+    const results = await runBatchMatrix(cells, { runCell });
+
+    expect(results[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('echoes model and inputRow onto the result for traceability', async () => {
+    const { runBatchMatrix } = await import('#src/BatchRunner.js');
+    const cell: MatrixCell = {
+      id: 'cell-0-0',
+      modelIndex: 0,
+      model: 'gpt-x',
+      inputIndex: 0,
+      inputRow: { a: '1' },
+      content: 'x',
+    };
+    const runCell: RunCellFn = async () => ({ ok: true });
+
+    const results = await runBatchMatrix([cell], { runCell });
+
+    expect(results[0].model).toEqual('gpt-x');
+    expect(results[0].inputRow).toEqual({ a: '1' });
+  });
+});
+
+describe('buildBatchSummary', () => {
+  it('counts total/passed/failed and includes a per-cell line', async () => {
+    const { buildBatchSummary } = await import('#src/BatchRunner.js');
+    const summary = buildBatchSummary([
+      { id: 'a', ok: true, inputIndex: 0, durationMs: 1, retries: 0 },
+      { id: 'b', ok: false, inputIndex: 1, durationMs: 1, retries: 1, error: 'nope' },
+      { id: 'c', ok: true, inputIndex: 2, durationMs: 1, retries: 0 },
+    ]);
+
+    expect(summary.total).toBe(3);
+    expect(summary.passed).toBe(2);
+    expect(summary.failed).toBe(1);
+    expect(summary.cells).toEqual([
+      { id: 'a', model: undefined, inputIndex: 0, ok: true, retries: 0 },
+      { id: 'b', model: undefined, inputIndex: 1, ok: false, retries: 1 },
+      { id: 'c', model: undefined, inputIndex: 2, ok: true, retries: 0 },
+    ]);
+  });
+
+  it('handles an empty result set', async () => {
+    const { buildBatchSummary } = await import('#src/BatchRunner.js');
+    const summary = buildBatchSummary([]);
+    expect(summary).toEqual({ total: 0, passed: 0, failed: 0, cells: [] });
+  });
+});

--- a/packages/batch/spec/interpolate.spec.ts
+++ b/packages/batch/spec/interpolate.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+describe('bindCellContent', () => {
+  it('passes content through unchanged when no row is supplied', async () => {
+    const { bindCellContent } = await import('#src/interpolate.js');
+    expect(bindCellContent('Do the thing.', undefined)).toEqual('Do the thing.');
+  });
+
+  it('substitutes {{field}} placeholders from the row', async () => {
+    const { bindCellContent } = await import('#src/interpolate.js');
+    const result = bindCellContent('Translate "{{text}}" into {{lang}}.', {
+      text: 'hello',
+      lang: 'French',
+    });
+    expect(result).toEqual('Translate "hello" into French.');
+  });
+
+  it('tolerates whitespace inside the braces', async () => {
+    const { bindCellContent } = await import('#src/interpolate.js');
+    const result = bindCellContent('Hello {{ name }}!', { name: 'Ada' });
+    expect(result).toEqual('Hello Ada!');
+  });
+
+  it('leaves a placeholder untouched when the row has no matching field', async () => {
+    const { bindCellContent } = await import('#src/interpolate.js');
+    const result = bindCellContent('Hello {{name}}, id {{missing}}.', { name: 'Ada' });
+    expect(result).toEqual('Hello Ada, id {{missing}}.');
+  });
+
+  it('appends the row as a fenced context block when the script has no placeholders', async () => {
+    const { bindCellContent } = await import('#src/interpolate.js');
+    const result = bindCellContent('Summarize the attached data.', {
+      id: '42',
+      category: 'widgets',
+    });
+    expect(result).toContain('Summarize the attached data.');
+    expect(result).toContain('<batch-row>');
+    expect(result).toContain('id: 42');
+    expect(result).toContain('category: widgets');
+    expect(result).toContain('</batch-row>');
+  });
+
+  it('does not append a context block when at least one placeholder matched', async () => {
+    const { bindCellContent } = await import('#src/interpolate.js');
+    const result = bindCellContent('Hello {{name}}.', { name: 'Ada', extra: 'unused' });
+    expect(result).not.toContain('<batch-row>');
+  });
+});

--- a/packages/batch/spec/matrix.spec.ts
+++ b/packages/batch/spec/matrix.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+describe('buildMatrix', () => {
+  it('produces a single cell when neither models nor rows are supplied', async () => {
+    const { buildMatrix } = await import('#src/matrix.js');
+    const cells = buildMatrix('Do the thing.', undefined, undefined);
+
+    expect(cells).toHaveLength(1);
+    expect(cells[0]).toMatchObject({
+      id: 'cell-0-0',
+      modelIndex: 0,
+      model: undefined,
+      inputIndex: 0,
+      inputRow: undefined,
+      content: 'Do the thing.',
+    });
+  });
+
+  it('fans out over models only (no --over)', async () => {
+    const { buildMatrix } = await import('#src/matrix.js');
+    const cells = buildMatrix('Do the thing.', ['a', 'b', 'c'], undefined);
+
+    expect(cells).toHaveLength(3);
+    expect(cells.map((c) => c.model)).toEqual(['a', 'b', 'c']);
+    expect(cells.map((c) => c.id)).toEqual(['cell-0-0', 'cell-1-0', 'cell-2-0']);
+    // Every cell gets the same content since there's no input axis to interpolate.
+    expect(cells.every((c) => c.content === 'Do the thing.')).toBe(true);
+  });
+
+  it('fans out over rows only (no --models)', async () => {
+    const { buildMatrix } = await import('#src/matrix.js');
+    const rows = [{ name: 'alice' }, { name: 'bob' }];
+    const cells = buildMatrix('Greet {{name}}.', undefined, rows);
+
+    expect(cells).toHaveLength(2);
+    expect(cells.map((c) => c.model)).toEqual([undefined, undefined]);
+    expect(cells.map((c) => c.id)).toEqual(['cell-0-0', 'cell-0-1']);
+    expect(cells.map((c) => c.content)).toEqual(['Greet alice.', 'Greet bob.']);
+    expect(cells.map((c) => c.inputRow)).toEqual(rows);
+  });
+
+  it('builds the full cross product when both axes are present', async () => {
+    const { buildMatrix } = await import('#src/matrix.js');
+    const rows = [{ name: 'alice' }, { name: 'bob' }];
+    const cells = buildMatrix('Greet {{name}}.', ['m1', 'm2'], rows);
+
+    expect(cells).toHaveLength(4);
+    expect(cells.map((c) => c.id)).toEqual(['cell-0-0', 'cell-0-1', 'cell-1-0', 'cell-1-1']);
+    expect(cells.map((c) => `${c.model}:${c.content}`)).toEqual([
+      'm1:Greet alice.',
+      'm1:Greet bob.',
+      'm2:Greet alice.',
+      'm2:Greet bob.',
+    ]);
+  });
+
+  it('treats an empty models/rows array the same as absent (no silent 0-cell matrix)', async () => {
+    const { buildMatrix } = await import('#src/matrix.js');
+    const cells = buildMatrix('Do the thing.', [], []);
+
+    expect(cells).toHaveLength(1);
+  });
+});

--- a/packages/batch/spec/output.spec.ts
+++ b/packages/batch/spec/output.spec.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { CellResult } from '#src/types.js';
+
+describe('writeBatchOutput', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'gth-batch-output-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes one JSON file per cell plus an aggregate results.json', async () => {
+    const { writeBatchOutput } = await import('#src/output.js');
+    const outputDir = join(dir, 'run-1');
+    const results: CellResult[] = [
+      { id: 'cell-0-0', ok: true, answer: 'hi', inputIndex: 0, durationMs: 12, retries: 0 },
+      { id: 'cell-0-1', ok: false, error: 'nope', inputIndex: 1, durationMs: 5, retries: 1 },
+    ];
+
+    const summary = writeBatchOutput(outputDir, results);
+
+    const cell0 = JSON.parse(readFileSync(join(outputDir, 'cell-0-0.json'), 'utf8'));
+    expect(cell0).toEqual(results[0]);
+
+    const cell1 = JSON.parse(readFileSync(join(outputDir, 'cell-0-1.json'), 'utf8'));
+    expect(cell1).toEqual(results[1]);
+
+    const resultsJson = JSON.parse(readFileSync(join(outputDir, 'results.json'), 'utf8'));
+    expect(resultsJson).toEqual(summary);
+    expect(summary.total).toBe(2);
+    expect(summary.passed).toBe(1);
+    expect(summary.failed).toBe(1);
+  });
+
+  it('creates the output directory (and parents) when it does not exist', async () => {
+    const { writeBatchOutput } = await import('#src/output.js');
+    const outputDir = join(dir, 'nested', 'deeper', 'run');
+
+    writeBatchOutput(outputDir, [
+      { id: 'cell-0-0', ok: true, inputIndex: 0, durationMs: 1, retries: 0 },
+    ]);
+
+    const content = readFileSync(join(outputDir, 'results.json'), 'utf8');
+    expect(JSON.parse(content).total).toBe(1);
+  });
+
+  it('handles an empty result set without throwing', async () => {
+    const { writeBatchOutput } = await import('#src/output.js');
+    const outputDir = join(dir, 'empty-run');
+
+    const summary = writeBatchOutput(outputDir, []);
+
+    expect(summary).toEqual({ total: 0, passed: 0, failed: 0, cells: [] });
+  });
+});

--- a/packages/batch/spec/parseOver.spec.ts
+++ b/packages/batch/spec/parseOver.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+describe('parseOverFile', () => {
+  describe('csv', () => {
+    it('parses a header row + data rows into records', async () => {
+      const { parseOverFile } = await import('#src/parseOver.js');
+      const rows = parseOverFile('cases.csv', 'name,city\nalice,paris\nbob,berlin\n');
+      expect(rows).toEqual([
+        { name: 'alice', city: 'paris' },
+        { name: 'bob', city: 'berlin' },
+      ]);
+    });
+
+    it('handles quoted fields containing commas and escaped quotes', async () => {
+      const { parseOverFile } = await import('#src/parseOver.js');
+      const rows = parseOverFile('cases.csv', 'name,quote\n"Smith, John","She said ""hi"""\n');
+      expect(rows).toEqual([{ name: 'Smith, John', quote: 'She said "hi"' }]);
+    });
+
+    it('skips blank lines', async () => {
+      const { parseOverFile } = await import('#src/parseOver.js');
+      const rows = parseOverFile('cases.csv', 'name\nalice\n\nbob\n');
+      expect(rows).toEqual([{ name: 'alice' }, { name: 'bob' }]);
+    });
+
+    it('throws on an empty file', async () => {
+      const { parseOverFile } = await import('#src/parseOver.js');
+      expect(() => parseOverFile('cases.csv', '')).toThrow(/empty CSV/);
+    });
+
+    it('throws when a row has a different field count than the header', async () => {
+      const { parseOverFile } = await import('#src/parseOver.js');
+      expect(() => parseOverFile('cases.csv', 'a,b\n1,2,3\n')).toThrow(/expected 2/);
+    });
+
+    it('throws when there is only a header row', async () => {
+      const { parseOverFile } = await import('#src/parseOver.js');
+      expect(() => parseOverFile('cases.csv', 'a,b\n')).toThrow(/no data rows/);
+    });
+  });
+
+  describe('jsonl', () => {
+    it('parses one JSON object per line (.jsonl)', async () => {
+      const { parseOverFile } = await import('#src/parseOver.js');
+      const rows = parseOverFile('cases.jsonl', '{"a":"1"}\n{"a":"2"}\n');
+      expect(rows).toEqual([{ a: '1' }, { a: '2' }]);
+    });
+
+    it('parses .ndjson the same way', async () => {
+      const { parseOverFile } = await import('#src/parseOver.js');
+      const rows = parseOverFile('cases.ndjson', '{"a":"1"}\n');
+      expect(rows).toEqual([{ a: '1' }]);
+    });
+
+    it('stringifies non-string field values', async () => {
+      const { parseOverFile } = await import('#src/parseOver.js');
+      const rows = parseOverFile('cases.jsonl', '{"n":42,"ok":true}\n');
+      expect(rows).toEqual([{ n: '42', ok: 'true' }]);
+    });
+
+    it('skips blank lines', async () => {
+      const { parseOverFile } = await import('#src/parseOver.js');
+      const rows = parseOverFile('cases.jsonl', '{"a":"1"}\n\n{"a":"2"}\n');
+      expect(rows).toEqual([{ a: '1' }, { a: '2' }]);
+    });
+
+    it('throws with the offending line number on invalid JSON', async () => {
+      const { parseOverFile } = await import('#src/parseOver.js');
+      expect(() => parseOverFile('cases.jsonl', '{"a":"1"}\nnot json\n')).toThrow(/line 2/);
+    });
+
+    it('throws when a line is a JSON array or scalar, not an object', async () => {
+      const { parseOverFile } = await import('#src/parseOver.js');
+      expect(() => parseOverFile('cases.jsonl', '[1,2,3]\n')).toThrow(/must be a JSON object/);
+    });
+
+    it('throws on an empty file', async () => {
+      const { parseOverFile } = await import('#src/parseOver.js');
+      expect(() => parseOverFile('cases.jsonl', '')).toThrow(/no rows/);
+    });
+  });
+});

--- a/packages/batch/src/BatchRunner.ts
+++ b/packages/batch/src/BatchRunner.ts
@@ -1,0 +1,119 @@
+import {
+  DEFAULT_CONCURRENCY,
+  type BatchRunnerOptions,
+  type BatchSummary,
+  type CellResult,
+  type MatrixCell,
+  type RunCellFn,
+} from '#src/types.js';
+
+/**
+ * Run every cell of the matrix through the injected {@link RunCellFn}, capping in-flight work at
+ * `concurrency` and retrying a failed cell up to `retry` times.
+ *
+ * Isolation: cells are independent by construction — nothing here shares state between them beyond
+ * the caller-supplied `runCell` closure, matching the "N isolated model calls" framing batch is
+ * scoped around (docs/batch-mechanism-vs-judgment.md). A cell throwing (rather than resolving
+ * `{ ok: false }`) is caught and recorded as a failure like any other — one bad cell must never
+ * take down the whole batch run or the other in-flight cells (the exit-code contract: `gth batch`
+ * exits 0 iff the cells ran at all, regardless of how many of them failed).
+ *
+ * Returns results in the same order as `cells` (not completion order), so callers can zip them back
+ * up with the matrix.
+ */
+export async function runBatchMatrix(
+  cells: MatrixCell[],
+  options: BatchRunnerOptions
+): Promise<CellResult[]> {
+  const concurrency = normalizeConcurrency(options.concurrency);
+  const retry = normalizeRetry(options.retry);
+  const results: CellResult[] = new Array(cells.length);
+
+  let nextIndex = 0;
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const i = nextIndex++;
+      if (i >= cells.length) return;
+      results[i] = await runCellWithRetry(cells[i], options.runCell, retry);
+    }
+  };
+
+  const workerCount = Math.min(concurrency, cells.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+  return results;
+}
+
+async function runCellWithRetry(
+  cell: MatrixCell,
+  runCell: RunCellFn,
+  retry: number
+): Promise<CellResult> {
+  const startedAt = Date.now();
+  let attempts = 0;
+  // Always at least one attempt; `retry` additional attempts on failure.
+  for (;;) {
+    attempts++;
+    try {
+      const outcome = await runCell(cell);
+      if (outcome.ok || attempts > retry) {
+        return {
+          ...outcome,
+          id: cell.id,
+          model: cell.model,
+          inputIndex: cell.inputIndex,
+          inputRow: cell.inputRow,
+          durationMs: Date.now() - startedAt,
+          retries: attempts - 1,
+        };
+      }
+      // Failed but retries remain: loop around for another attempt.
+    } catch (error) {
+      if (attempts > retry) {
+        return {
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+          id: cell.id,
+          model: cell.model,
+          inputIndex: cell.inputIndex,
+          inputRow: cell.inputRow,
+          durationMs: Date.now() - startedAt,
+          retries: attempts - 1,
+        };
+      }
+      // Exception with retries remaining: loop around for another attempt.
+    }
+  }
+}
+
+function normalizeConcurrency(concurrency: number | undefined): number {
+  if (concurrency === undefined || !Number.isFinite(concurrency) || concurrency < 1) {
+    return DEFAULT_CONCURRENCY;
+  }
+  return Math.floor(concurrency);
+}
+
+function normalizeRetry(retry: number | undefined): number {
+  if (retry === undefined || !Number.isFinite(retry) || retry < 0) {
+    return 0;
+  }
+  return Math.floor(retry);
+}
+
+/** Build the lightweight aggregate "flake report" (pass/fail counts) from the per-cell results. */
+export function buildBatchSummary(results: CellResult[]): BatchSummary {
+  const cells = results.map((r) => ({
+    id: r.id,
+    model: r.model,
+    inputIndex: r.inputIndex,
+    ok: r.ok,
+    retries: r.retries,
+  }));
+  const passed = cells.filter((c) => c.ok).length;
+  return {
+    total: cells.length,
+    passed,
+    failed: cells.length - passed,
+    cells,
+  };
+}

--- a/packages/batch/src/index.ts
+++ b/packages/batch/src/index.ts
@@ -1,0 +1,15 @@
+export { buildMatrix } from '#src/matrix.js';
+export { bindCellContent } from '#src/interpolate.js';
+export { parseOverFile } from '#src/parseOver.js';
+export { runBatchMatrix, buildBatchSummary } from '#src/BatchRunner.js';
+export { writeBatchOutput } from '#src/output.js';
+export type {
+  BatchRunnerOptions,
+  BatchSummary,
+  CellResult,
+  CellRunOutcome,
+  MatrixCell,
+  MatrixRow,
+  RunCellFn,
+} from '#src/types.js';
+export { DEFAULT_CONCURRENCY } from '#src/types.js';

--- a/packages/batch/src/interpolate.ts
+++ b/packages/batch/src/interpolate.ts
@@ -1,0 +1,54 @@
+import type { MatrixRow } from '#src/types.js';
+
+/**
+ * BATCH-1 cell-binding syntax: `{{field}}` placeholders.
+ *
+ * Matches a bare field name (letters/digits/`_`/`.`/`-`), optionally surrounded by whitespace
+ * inside the braces (`{{ field }}` also works). Chosen over a heavier templating engine (mustache,
+ * handlebars-with-helpers, …) because BATCH-1's job is a literal find/replace of csv/jsonl column
+ * values into prose — no conditionals or loops belong in a prompt-executable script, and `{{x}}` is
+ * the syntax #405's own case format already uses for template-ish values, so it needs no new
+ * mental model for that user.
+ */
+const PLACEHOLDER_RE = /\{\{\s*([\w.-]+)\s*\}\}/g;
+
+/**
+ * Bind one input row into a script's content.
+ *
+ * - Every `{{field}}` placeholder whose `field` is a key of `row` is replaced with that value.
+ * - A placeholder naming a field the row doesn't have is left untouched (fail-soft: a typo in the
+ *   script doesn't blow up the run, it just doesn't get substituted — visible in the recorded
+ *   per-cell content if you go looking).
+ * - When the script contains **no** placeholder that matched any row field at all, the row is
+ *   appended as a fenced context block instead of silently dropped. This covers the "script has no
+ *   placeholders" case BATCH-1's own scope note calls out explicitly: a script that never mentions
+ *   `{{...}}` still needs the row's data available to the model, just not spliced into prose.
+ *
+ * `row` undefined (no `--over`) is a no-op passthrough.
+ */
+export function bindCellContent(baseContent: string, row: MatrixRow | undefined): string {
+  if (!row) {
+    return baseContent;
+  }
+
+  let matchedAny = false;
+  const bound = baseContent.replace(PLACEHOLDER_RE, (full, field: string) => {
+    if (Object.prototype.hasOwnProperty.call(row, field)) {
+      matchedAny = true;
+      return row[field];
+    }
+    return full;
+  });
+
+  if (matchedAny) {
+    return bound;
+  }
+
+  return `${bound}\n\n${formatRowAsContextBlock(row)}`;
+}
+
+/** Render a row as a small fenced block of `key: value` lines, for the no-placeholder fallback. */
+function formatRowAsContextBlock(row: MatrixRow): string {
+  const lines = Object.entries(row).map(([key, value]) => `${key}: ${value}`);
+  return ['Batch input row for this cell:', '<batch-row>', ...lines, '</batch-row>'].join('\n');
+}

--- a/packages/batch/src/matrix.ts
+++ b/packages/batch/src/matrix.ts
@@ -1,0 +1,37 @@
+import { bindCellContent } from '#src/interpolate.js';
+import type { MatrixCell, MatrixRow } from '#src/types.js';
+
+/**
+ * Build the batch matrix: the cross product of the model axis (`--models`, absent = a single
+ * `undefined`-model cell using the resolved config's model) and the input axis (`--over`, absent =
+ * a single `undefined`-row cell using the script's own content, exactly like `exec`).
+ *
+ * `models`/`rows` pass `undefined` (not an empty array) to mean "axis absent" — an empty array is
+ * treated as a caller bug and also collapses to "absent" defensively, since a 0-cell matrix would
+ * silently do nothing.
+ */
+export function buildMatrix(
+  baseContent: string,
+  models: string[] | undefined,
+  rows: MatrixRow[] | undefined
+): MatrixCell[] {
+  const modelAxis = models && models.length > 0 ? models : [undefined];
+  const rowAxis = rows && rows.length > 0 ? rows : [undefined];
+
+  const cells: MatrixCell[] = [];
+  for (let mi = 0; mi < modelAxis.length; mi++) {
+    for (let ri = 0; ri < rowAxis.length; ri++) {
+      const model = modelAxis[mi];
+      const row = rowAxis[ri];
+      cells.push({
+        id: `cell-${mi}-${ri}`,
+        modelIndex: mi,
+        model,
+        inputIndex: ri,
+        inputRow: row,
+        content: bindCellContent(baseContent, row),
+      });
+    }
+  }
+  return cells;
+}

--- a/packages/batch/src/output.ts
+++ b/packages/batch/src/output.ts
@@ -1,0 +1,28 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { buildBatchSummary } from '#src/BatchRunner.js';
+import type { BatchSummary, CellResult } from '#src/types.js';
+
+/**
+ * Write one structured JSON record per cell (`<id>.json`) plus one aggregate `results.json`
+ * (pass/fail counts + a per-cell one-liner — a lightweight flake report) into `outputDir`.
+ * Creates `outputDir` (and any missing parents) if it doesn't exist.
+ *
+ * Pure I/O, deliberately separate from {@link runBatchMatrix}: the runner never touches the
+ * filesystem, so unit tests can exercise matrix/concurrency/retry logic without a tmp dir, and this
+ * function can be tested in isolation with a fixed set of results.
+ *
+ * @returns The aggregate {@link BatchSummary} that was written to `results.json`.
+ */
+export function writeBatchOutput(outputDir: string, results: CellResult[]): BatchSummary {
+  mkdirSync(outputDir, { recursive: true });
+
+  for (const result of results) {
+    writeFileSync(join(outputDir, `${result.id}.json`), `${JSON.stringify(result, null, 2)}\n`);
+  }
+
+  const summary = buildBatchSummary(results);
+  writeFileSync(join(outputDir, 'results.json'), `${JSON.stringify(summary, null, 2)}\n`);
+
+  return summary;
+}

--- a/packages/batch/src/parseOver.ts
+++ b/packages/batch/src/parseOver.ts
@@ -1,0 +1,124 @@
+import type { MatrixRow } from '#src/types.js';
+
+/**
+ * Parse `--over <path>` content into matrix rows. Format is chosen by file extension:
+ * `.jsonl`/`.ndjson` → one JSON object per line; anything else (including `.csv`) → CSV.
+ *
+ * This is content binding only (BATCH-1 scope): every row becomes an object of string fields that
+ * {@link bindCellContent} interpolates into the script. A glob-of-binary-files path binding is out
+ * of scope for this task.
+ *
+ * Throws a descriptive `Error` on malformed input — the harness-level failure the CLI surface doc
+ * calls out as the one thing that should make `gth batch` exit non-zero (a bad row/cell answer
+ * never should).
+ */
+export function parseOverFile(filePath: string, content: string): MatrixRow[] {
+  const isJsonl = /\.(jsonl|ndjson)$/i.test(filePath);
+  return isJsonl ? parseJsonl(filePath, content) : parseCsv(filePath, content);
+}
+
+function parseJsonl(filePath: string, content: string): MatrixRow[] {
+  const rows: MatrixRow[] = [];
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line.length === 0) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch (error) {
+      throw new Error(
+        `--over ${filePath}: invalid JSON on line ${i + 1}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error(
+        `--over ${filePath}: line ${i + 1} must be a JSON object, got ${JSON.stringify(parsed)}`
+      );
+    }
+    rows.push(stringifyRowValues(parsed as Record<string, unknown>));
+  }
+  if (rows.length === 0) {
+    throw new Error(`--over ${filePath}: no rows found (empty JSONL file)`);
+  }
+  return rows;
+}
+
+function stringifyRowValues(record: Record<string, unknown>): MatrixRow {
+  const row: MatrixRow = {};
+  for (const [key, value] of Object.entries(record)) {
+    row[key] = typeof value === 'string' ? value : JSON.stringify(value);
+  }
+  return row;
+}
+
+/** Minimal RFC4180 CSV parser (quoted fields, escaped `""`, CRLF/LF), header row = field names. */
+function parseCsvLines(text: string): string[][] {
+  const rows: string[][] = [];
+  let field = '';
+  let row: string[] = [];
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ',') {
+      row.push(field);
+      field = '';
+    } else if (c === '\n') {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = '';
+    } else if (c !== '\r') {
+      field += c;
+    }
+  }
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+  return rows;
+}
+
+function parseCsv(filePath: string, content: string): MatrixRow[] {
+  const raw = parseCsvLines(content);
+  if (raw.length === 0) {
+    throw new Error(`--over ${filePath}: empty CSV file (no header row)`);
+  }
+
+  const header = raw[0].map((h) => h.trim());
+  if (header.length === 0 || header.every((h) => h.length === 0)) {
+    throw new Error(`--over ${filePath}: CSV header row is empty`);
+  }
+
+  const rows = raw
+    .slice(1)
+    .filter((r) => r.some((c) => c.trim() !== ''))
+    .map((r) => {
+      if (r.length !== header.length) {
+        throw new Error(
+          `--over ${filePath}: row has ${r.length} field(s), expected ${header.length} to match the header`
+        );
+      }
+      return Object.fromEntries(header.map((h, i) => [h, (r[i] ?? '').trim()])) as MatrixRow;
+    });
+
+  if (rows.length === 0) {
+    throw new Error(`--over ${filePath}: no data rows found (only a header row)`);
+  }
+  return rows;
+}

--- a/packages/batch/src/types.ts
+++ b/packages/batch/src/types.ts
@@ -1,0 +1,104 @@
+/**
+ * @packageDocumentation
+ * BATCH-1 — the shapes shared across matrix construction, the concurrency/retry runner, and the
+ * structured output writer. Deliberately independent of any LLM/runner types (`GthConfig`,
+ * `runSingleShot`, …): this package only knows about *cells* and *outcomes*. The production
+ * adapter that turns a cell into an actual `runSingleShot` call lives in
+ * `packages/app/src/commands/batchCommand.ts`, which is what keeps {@link RunCellFn} injectable —
+ * unit tests here fake it, the CLI wires the real one.
+ */
+
+/** One row/record parsed from `--over <path.csv|path.jsonl>`. Values are always strings for csv. */
+export type MatrixRow = Record<string, string>;
+
+/**
+ * One cell of the batch matrix — the cross product of the model axis (`--models`) and the input
+ * axis (`--over`). Either axis may be absent (single cell using the resolved config's model and/or
+ * the script's own content, mirroring `exec` with no matrix at all).
+ */
+export interface MatrixCell {
+  /**
+   * Filename-safe, deterministic identifier: `cell-<modelIndex>-<rowIndex>` (0-based; both
+   * default to 0 when their axis is absent). Never derived from the model name or row content so
+   * it stays stable and filesystem-safe regardless of what a model/provider string or row data
+   * contains.
+   */
+  id: string;
+  /** 0-based index into the (possibly single-element) model axis. */
+  modelIndex: number;
+  /** The model name for this cell, when `--models` was supplied. Absent = the configured model. */
+  model?: string;
+  /** 0-based index into the (possibly single-element) input axis. */
+  inputIndex: number;
+  /** The source row for this cell, when `--over` was supplied. Absent = no input axis. */
+  inputRow?: MatrixRow;
+  /** The fully-bound prompt content for this cell (base script content with the row interpolated). */
+  content: string;
+}
+
+/** What one attempt at running a cell through the shared single-shot runtime produced. */
+export interface CellRunOutcome {
+  /** `true` when the cell's run completed without error; mirrors `runSingleShot`'s contract. */
+  ok: boolean;
+  /**
+   * The model's final answer text, when the injected run-cell function can cleanly obtain it.
+   * The production adapter (wired around `runSingleShot`) cannot — see the BATCH-1 task report for
+   * why — so this is `undefined` for real runs today; fakes used in tests may populate it.
+   */
+  answer?: string;
+  /** Total prompt/input tokens for the run, when available (see {@link answer}'s caveat). */
+  tokensInput?: number;
+  /** Total completion/output tokens for the run, when available (see {@link answer}'s caveat). */
+  tokensOutput?: number;
+  /** Names of tools invoked during the run, when available (see {@link answer}'s caveat). */
+  tools?: string[];
+  /** A human-readable failure reason, set when `ok` is `false`. */
+  error?: string;
+}
+
+/**
+ * Injectable "run one prompt" function — the seam that lets {@link runBatchMatrix} be fully unit
+ * tested without any real LLM call. The production wiring (`batchCommand.ts`) adapts
+ * `runSingleShot` to this shape; tests inject a fake that resolves/rejects/throws as needed.
+ */
+export type RunCellFn = (cell: MatrixCell) => Promise<CellRunOutcome>;
+
+/** One cell's full structured record, as written to `<id>.json` and summarized in `results.json`. */
+export interface CellResult extends CellRunOutcome {
+  id: string;
+  model?: string;
+  inputIndex: number;
+  /** The source row for this cell, echoed for traceability (absent when no `--over` was given). */
+  inputRow?: MatrixRow;
+  /** Wall-clock time across all attempts (including retries) for this cell, in milliseconds. */
+  durationMs: number;
+  /** How many retries were consumed (0 = succeeded, or failed, on the first attempt). */
+  retries: number;
+}
+
+/** Options for {@link runBatchMatrix}. */
+export interface BatchRunnerOptions {
+  /** Max in-flight cells. Must be >= 1; non-finite/invalid values fall back to the default. */
+  concurrency?: number;
+  /** Number of retries on a failed cell (0 = no retry, the default). */
+  retry?: number;
+  /** The injectable per-cell run function (see {@link RunCellFn}). */
+  runCell: RunCellFn;
+}
+
+/** A lightweight, `--repeat`-free version of the "flake report" §3 of the requirements asks for. */
+export interface BatchSummary {
+  total: number;
+  passed: number;
+  failed: number;
+  cells: Array<{
+    id: string;
+    model?: string;
+    inputIndex: number;
+    ok: boolean;
+    retries: number;
+  }>;
+}
+
+/** The default concurrency cap when `-j/--concurrency` is not supplied. */
+export const DEFAULT_CONCURRENCY = 4;

--- a/packages/batch/tsconfig.json
+++ b/packages/batch/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "allowJs": true,
+    "checkJs": false,
+    "types": ["node"],
+    "typeRoots": ["../../node_modules/@types"],
+    "paths": {
+      "#src/*": [
+        "./src/*"
+      ]
+    }
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/core/spec/config.spec.ts
+++ b/packages/core/spec/config.spec.ts
@@ -1591,6 +1591,124 @@ describe('config', async () => {
       expect(postProcessJsonConfigMock).toHaveBeenCalledOnce();
       expect(finalConfig).toEqual(postProcessedConfig);
     });
+
+    describe('commandLineConfigOverrides.model (BATCH-1)', () => {
+      it('overrides llmConfig.model before the provider builds the instance', async () => {
+        const jsonConfig = {
+          llm: {
+            type: 'vertexai',
+            model: 'configured-model',
+          },
+        } as RawGthConfig;
+
+        const processJsonConfigMock = vi
+          .fn()
+          .mockImplementation(async (llmConfig: Record<string, unknown>) => ({
+            type: 'vertexai',
+            model: llmConfig.model,
+          }));
+        vi.doMock('#src/providers/vertexai.js', () => ({
+          processJsonConfig: processJsonConfigMock,
+          postProcessJsonConfig: undefined,
+        }));
+
+        const { tryJsonConfig } = await import('#src/config.js');
+        const config = await tryJsonConfig(jsonConfig, { model: 'override-model' });
+
+        // The override must reach the provider's own construction call (the raw LLM *spec*),
+        // not be applied after the fact to whatever instance was already built.
+        expect(processJsonConfigMock).toHaveBeenCalledWith(
+          expect.objectContaining({ model: 'override-model' })
+        );
+        expect(config.llm).toEqual({ type: 'vertexai', model: 'override-model' });
+        // modelDisplayName is derived from the (now-overridden) raw jsonConfig.llm.model.
+        expect(config.modelDisplayName).toEqual('override-model');
+      });
+
+      it(
+        'regression (BATCH-1 finding 1): builds a genuine instance via the provider factory, so ' +
+          'a provider class with a real private field keeps working — no Object.create/' +
+          'getOwnPropertyDescriptors structural clone anywhere in this path',
+        async () => {
+          // A minimal stand-in for a LangChain chat-model class whose methods touch a genuine
+          // private (#) field — the exact shape the old `cloneLlmWithModel` (Object.create +
+          // getOwnPropertyDescriptors) could never support, because a structurally-cloned object
+          // never runs the constructor and so never gets the original instance's private slots.
+          class FakeProviderModelWithPrivateField {
+            model: string;
+            #internalClient: { greet: () => string };
+
+            constructor(fields: { model: string }) {
+              this.model = fields.model;
+              // A "real internal client cache" a provider might build in its constructor —
+              // exactly the kind of state a structural clone would never receive.
+              this.#internalClient = { greet: () => `hello from ${fields.model}` };
+            }
+
+            // Any real call path (e.g. `.invoke()`) would touch private state like this;
+            // this throws `TypeError: Cannot read private member ...` on an Object.create clone.
+            callPrivate(): string {
+              return this.#internalClient.greet();
+            }
+          }
+
+          const jsonConfig = {
+            llm: {
+              type: 'vertexai',
+              model: 'configured-model',
+            },
+          } as RawGthConfig;
+
+          vi.doMock('#src/providers/vertexai.js', () => ({
+            processJsonConfig: vi
+              .fn()
+              .mockImplementation(
+                async (llmConfig: Record<string, unknown>) =>
+                  new FakeProviderModelWithPrivateField({ model: llmConfig.model as string })
+              ),
+            postProcessJsonConfig: undefined,
+          }));
+
+          const { tryJsonConfig } = await import('#src/config.js');
+          const config = await tryJsonConfig(jsonConfig, { model: 'model-with-private-state' });
+
+          const llm = config.llm as unknown as FakeProviderModelWithPrivateField;
+          expect(llm).toBeInstanceOf(FakeProviderModelWithPrivateField);
+          // The critical assertion: calling a method that reaches into the private field does
+          // NOT throw. A structurally-cloned object (Object.create + getOwnPropertyDescriptors)
+          // would throw here, because it never ran the constructor that sets #internalClient.
+          expect(llm.callPrivate()).toEqual('hello from model-with-private-state');
+        }
+      );
+
+      it('leaves llmConfig.model untouched when no override is given', async () => {
+        const jsonConfig = {
+          llm: {
+            type: 'vertexai',
+            model: 'configured-model',
+          },
+        } as RawGthConfig;
+
+        const processJsonConfigMock = vi
+          .fn()
+          .mockImplementation(async (llmConfig: Record<string, unknown>) => ({
+            type: 'vertexai',
+            model: llmConfig.model,
+          }));
+        vi.doMock('#src/providers/vertexai.js', () => ({
+          processJsonConfig: processJsonConfigMock,
+          postProcessJsonConfig: undefined,
+        }));
+
+        const { tryJsonConfig } = await import('#src/config.js');
+        const config = await tryJsonConfig(jsonConfig, {});
+
+        expect(processJsonConfigMock).toHaveBeenCalledWith(
+          expect.objectContaining({ model: 'configured-model' })
+        );
+        expect(config.modelDisplayName).toEqual('configured-model');
+      });
+    });
   });
 
   describe('custom config path', () => {

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -543,6 +543,12 @@ export async function tryJsonConfig(
         // Necessary to avoid https://github.com/langchain-ai/langchainjs/issues/8705
         llmConfig.verbose = commandLineConfigOverrides.verbose;
       }
+      if (commandLineConfigOverrides.model) {
+        // BATCH-1 fix — see CommandLineConfigOverrides.model: retarget the raw LLM *spec* before
+        // the provider builds an instance from it, rather than cloning/mutating an already-built
+        // instance. `gth batch --models` is the only current caller.
+        llmConfig.model = commandLineConfigOverrides.model;
+      }
       // Import the appropriate config module
       const configModule = await import(`#src/providers/${llmType}.js`);
       if (configModule.processJsonConfig) {

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -530,4 +530,19 @@ export interface CommandLineConfigOverrides {
    * The decision itself lives in `gaunt-sloth`'s `shouldUseTui`; this only carries the flag.
    */
   tui?: boolean;
+  /**
+   * BATCH-1 fix — run with a different model than the configured `llm.model`, just for this
+   * `initConfig()` call. Used by `gth batch --models a,b,c` to build one genuinely fresh
+   * `GthConfig` (with its own freshly-constructed `.llm`) per distinct model in the matrix,
+   * instead of structurally cloning an already-instantiated LangChain model object (unsafe for
+   * any provider class that keeps state behind private `#fields`). Applied in
+   * {@link tryJsonConfig} by overriding `llmConfig.model` before the provider's
+   * `processJsonConfig()` builds the instance, so it flows through the same supported
+   * construction path every other model comes from.
+   *
+   * Only takes effect for JSON (`.gsloth.config.json`) configs — a `configure()`-style JS/MJS/TS
+   * module config already returns a fully-built `GthConfig` (LLM included) with no generic seam
+   * to re-target its model.
+   */
+  model?: string;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       '@gaunt-sloth/agent':
         specifier: workspace:*
         version: link:../agent
+      '@gaunt-sloth/batch':
+        specifier: workspace:*
+        version: link:../batch
       '@gaunt-sloth/core':
         specifier: workspace:*
         version: link:../core
@@ -184,6 +187,12 @@ importers:
       react:
         specifier: ^19.2.7
         version: 19.2.7
+
+  packages/batch:
+    dependencies:
+      '@gaunt-sloth/core':
+        specifier: workspace:*
+        version: link:../core
 
   packages/core:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     { "path": "packages/core" },
     { "path": "packages/agent" },
     { "path": "packages/review" },
+    { "path": "packages/batch" },
     { "path": "packages/app" }
   ],
   "files": [],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
  * source files in the workspace packages. This ensures that vi.mock() and
  * dynamic imports all resolve to the same module identity.
  *
- * Packages are scanned in dependency order: core → agent → tools → review → api → app.
+ * Packages are scanned in dependency order: core → agent → review → batch → app.
  * The review package has re-export stubs that delegate to core; those are
  * detected and skipped so the canonical core module is always used.
  */
@@ -34,7 +34,7 @@ function resolveWorkspaceImports() {
         const relative = id.replace('#src/', '').replace(/\.js$/, '');
 
         // Try each package in dependency order
-        for (const pkg of ['core', 'agent', 'review', 'app']) {
+        for (const pkg of ['core', 'agent', 'review', 'batch', 'app']) {
           const found = resolveSource(resolve(__dirname, `packages/${pkg}/src/${relative}`));
           if (found) {
             // Skip re-export stubs (files that just re-export from @gaunt-sloth/)
@@ -51,7 +51,7 @@ function resolveWorkspaceImports() {
       }
 
       // Handle @gaunt-sloth/X/path.js -> packages/X/src/path.{ts,tsx}
-      const scopedMatch = id.match(/^@gaunt-sloth\/(core|agent|review)\/(.+)\.js$/);
+      const scopedMatch = id.match(/^@gaunt-sloth\/(core|agent|review|batch)\/(.+)\.js$/);
       if (scopedMatch) {
         const [, pkg, path] = scopedMatch;
         return resolveSource(resolve(__dirname, `packages/${pkg}/src/${path}`));


### PR DESCRIPTION
## Summary
- New `@gaunt-sloth/batch` workspace package: matrix construction (models × csv/jsonl-row cross-product), `{{field}}` cell-binding interpolation, concurrency-capped + retrying `runBatchMatrix` with an injectable per-cell run function, structured per-cell + aggregate JSON output.
- New `gth batch <script> --over <csv|jsonl> [--models a,b,c] [-j N] [--retry N] [-o dir]` CLI command wired into `packages/app`, sharing the `runSingleShot` single-shot runtime (same primitive `ask`/`exec` use).
- Exit-code contract: process exits 0 even when individual cells fail — batch's job is running the cells, not judging them (that's `gth eval`, BATCH-2, not in this PR).

## Scope
First task of the [[BATCH-1]] work-graph node (project-takahe). Deliberately excludes (tracked as remaining BATCH-1 scope): `gth eval`/BATCH-2, glob/path-bound binary cell input, pluggable HTTP/CLI targets, the `ask`/`review` `--json` envelope, `--repeat`/flake-rate reporting.

## Test plan
- [x] `pnpm run build` clean
- [x] `pnpm run lint` clean
- [x] `pnpm run unit` — 1575 passed / 3 skipped, no regressions (independently re-verified, not just self-reported)
- [x] Manual CLI smoke test against the built-in fake LLM provider: concurrent `-j 2` execution, `--models`/`--over` fan-out, structured JSON output, exit-code contract
- [x] Full spec-then-quality subagent review: both PASS, no Critical/Important findings

🤖 Generated with a project-takahe coordinator + subagent workflow.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>