### PR TITLE
feat(tui): add /debug-dump slash command (GS2-46, unsanitized v1)

### DIFF
--- a/packages/app/spec/tui/slashCommands.spec.ts
+++ b/packages/app/spec/tui/slashCommands.spec.ts
@@ -430,6 +430,97 @@ describe('tui/slashCommands /reasoning (TUI-C18 recall a turn’s thinking)', ()
   });
 });
 
+describe('tui/slashCommands /debug-dump (GS2-46)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('calls the injected dumpDebugSession with the transcript/config/model and renders the path + sensitive-data warning', async () => {
+    const { createCommandRegistry, dispatchSlashCommand, parseSlashCommand } =
+      await import('#src/tui/slashCommands.js');
+    const dumpDebugSession = vi.fn().mockReturnValue({
+      archiveDir: '/home/user/.gsloth/debug-dumps/2026-07-18T12-00-00-000Z',
+    });
+    const fakeTranscript = [{ kind: 'user', id: 1, text: 'hi' }];
+    const fakeConfig = { modelDisplayName: 'claude-opus-4' };
+
+    const result = dispatchSlashCommand(
+      parseSlashCommand('/debug-dump')!,
+      createCommandRegistry(),
+      {
+        ...ctx,
+        transcript: fakeTranscript,
+        resolvedConfig: fakeConfig,
+        dumpDebugSession,
+      }
+    );
+
+    expect(dumpDebugSession).toHaveBeenCalledWith({
+      transcript: fakeTranscript,
+      config: fakeConfig,
+      modelDisplayName: ctx.modelDisplayName,
+    });
+
+    // Acceptance criteria: the returned notice contains BOTH the archive path and the warning.
+    const allText = [result.notice?.title, ...(result.notice?.lines ?? [])].join('\n');
+    expect(allText).toContain('/home/user/.gsloth/debug-dumps/2026-07-18T12-00-00-000Z');
+    expect(allText.toLowerCase()).toContain('secrets');
+    expect(allText.toLowerCase()).toContain('unsanitized');
+    expect(result.notice?.tone).toBe('warn');
+  });
+
+  it('defaults transcript to [] and passes through an undefined resolvedConfig when the context omits them', async () => {
+    const { createCommandRegistry, dispatchSlashCommand, parseSlashCommand } =
+      await import('#src/tui/slashCommands.js');
+    const dumpDebugSession = vi.fn().mockReturnValue({ archiveDir: '/tmp/whatever' });
+
+    dispatchSlashCommand(parseSlashCommand('/debug-dump')!, createCommandRegistry(), {
+      ...ctx,
+      dumpDebugSession,
+    });
+
+    expect(dumpDebugSession).toHaveBeenCalledWith({
+      transcript: [],
+      config: undefined,
+      modelDisplayName: ctx.modelDisplayName,
+    });
+  });
+
+  it('reports itself unavailable (never throws) when no dumpDebugSession writer is injected', async () => {
+    const { createCommandRegistry, dispatchSlashCommand, parseSlashCommand } =
+      await import('#src/tui/slashCommands.js');
+    const result = dispatchSlashCommand(
+      parseSlashCommand('/debug-dump')!,
+      createCommandRegistry(),
+      ctx // fixture-style context: no dumpDebugSession
+    );
+    expect(result.notice?.title).toBe('Debug dump unavailable');
+    expect(result.notice?.lines.join(' ')).toContain('No debug-dump writer is available');
+  });
+
+  it('stays run-safe: it is dispatchable while a turn is streaming', async () => {
+    const { createCommandRegistry, dispatchSlashCommand, parseSlashCommand } =
+      await import('#src/tui/slashCommands.js');
+    const dumpDebugSession = vi.fn().mockReturnValue({ archiveDir: '/tmp/mid-turn-dump' });
+    const result = dispatchSlashCommand(
+      parseSlashCommand('/debug-dump')!,
+      createCommandRegistry(),
+      { ...ctx, dumpDebugSession },
+      { duringRun: true }
+    );
+    expect(dumpDebugSession).toHaveBeenCalled();
+    expect(result.notice?.title).toContain('Debug dump written');
+  });
+
+  it('is listed in /help', async () => {
+    const { createCommandRegistry, dispatchSlashCommand, parseSlashCommand } =
+      await import('#src/tui/slashCommands.js');
+    const registry = createCommandRegistry();
+    const result = dispatchSlashCommand(parseSlashCommand('/help')!, registry, ctx);
+    expect(result.notice?.lines.some((l) => l.startsWith('/debug-dump —'))).toBe(true);
+  });
+});
+
 describe('tui/slashCommands slashMenuQuery (TUI-C10 menu trigger)', () => {
   beforeEach(() => {
     vi.resetAllMocks();

--- a/packages/app/src/tui/components/App.tsx
+++ b/packages/app/src/tui/components/App.tsx
@@ -403,6 +403,11 @@ export function App(props: TuiAppProps): React.ReactElement {
                 (i): i is Extract<TranscriptItem, { kind: 'assistant' }> => i.kind === 'assistant'
               )
               .map((i) => i.turn.reasoning),
+            // GS2-46 — the full live transcript + resolved config for /debug-dump, plus the
+            // injected fs-writing implementation (undefined for the fixture agent).
+            transcript: transcriptRef.current,
+            resolvedConfig: props.resolvedConfig,
+            dumpDebugSession: props.dumpDebugSession,
           },
           { duringRun: running }
         );

--- a/packages/app/src/tui/slashCommands.ts
+++ b/packages/app/src/tui/slashCommands.ts
@@ -58,6 +58,37 @@ export interface SlashCommandContext {
    * builds this from the transcript; omitted (empty) where there are no committed turns yet.
    */
   turnReasonings?: string[];
+  /**
+   * GS2-46 — the live transcript (all committed turns, tool calls + results) and the resolved
+   * config, for `/debug-dump`. Kept opaque (`unknown`) so this pure module stays decoupled from
+   * the TUI's `TranscriptItem` type and `GthConfig` — forwarded as-is into the injected
+   * `dumpDebugSession` writer (see {@link DebugDumpInput}). Omitted where no session state is
+   * available (e.g. the fixture agent), in which case `/debug-dump` reports itself unavailable.
+   */
+  transcript?: unknown[];
+  /** GS2-46 — see {@link SlashCommandContext.transcript}. */
+  resolvedConfig?: unknown;
+  /**
+   * GS2-46 — fs-writing implementation for `/debug-dump`: writes an UNSANITIZED archive
+   * (transcript, resolved config, env/version info, the in-memory debugLog ring buffer, and
+   * best-effort git repo state) to `~/.gsloth/debug-dumps/<timestamp>/` and returns its path.
+   * Injected by the App the same way `historySearch` is (GS2-7), so this module stays pure and
+   * testable with a fake — the real writer (`packages/core/src/utils/debugDump.ts`) does the
+   * actual I/O. Omitted ⇒ `/debug-dump` reports itself unavailable (fixture / no session state).
+   */
+  dumpDebugSession?: (input: DebugDumpInput) => { archiveDir: string };
+}
+
+/**
+ * GS2-46 — the input `/debug-dump` assembles from context and hands to the injected
+ * `dumpDebugSession` writer. `transcript`/`config` are opaque to this pure module (the real
+ * writer, not this file, interprets them); `modelDisplayName` mirrors the field already on
+ * {@link SlashCommandContext}.
+ */
+export interface DebugDumpInput {
+  transcript: unknown[];
+  config: unknown;
+  modelDisplayName: string;
 }
 
 /**
@@ -447,6 +478,32 @@ export function resolveReasoning(reasonings: string[], args: string[]): SlashCom
   };
 }
 
+/** `/debug-dump` when no `dumpDebugSession` writer is injected (fixture agent / no session state). */
+const DEBUG_DUMP_UNAVAILABLE_LINES = [
+  'No debug-dump writer is available in this session.',
+  'This is only available in a real session (not the fixture/demo agent).',
+];
+
+/**
+ * The `/debug-dump` success notice (GS2-46): the archive path plus a loud, impossible-to-miss
+ * warning. This node ships deliberately UNSANITIZED — the user ran this command themselves,
+ * mid-session, knowingly — so the warning stands in for the redaction GS2-47 adds later. `tone:
+ * 'warn'` (yellow, bold title) so the block itself reads as caution, not just its body text.
+ */
+export function debugDumpNotice(archiveDir: string): SlashCommandNotice {
+  return {
+    title: '⚠️  Debug dump written — UNSANITIZED, review before sharing',
+    lines: [
+      `Archive: ${archiveDir}`,
+      '',
+      'This archive contains the full transcript, resolved config, env info, debug log and git',
+      'state AS-IS — it may include secrets: API keys, tokens, file contents, env vars.',
+      'Review it carefully before sending it anywhere.',
+    ],
+    tone: 'warn',
+  };
+}
+
 /**
  * Build the default command registry. Returns a fresh array each call so callers may push
  * extension commands onto it (EXT-5) without sharing mutable module state.
@@ -584,6 +641,32 @@ export function createCommandRegistry(): SlashCommand[] {
       // Pure: resolve the target from the App-provided committed reasonings; the App renders the
       // reprint (reusing TUI-C15 styling) or the friendly notice.
       run: (ctx, args) => resolveReasoning(ctx.turnReasonings ?? [], args),
+    },
+    {
+      name: 'debug-dump',
+      description:
+        'Dump transcript + config + env + debug log to ~/.gsloth/debug-dumps (UNSANITIZED — may contain secrets)',
+      // Read-only from the transcript/thread's perspective (it only writes a diagnostic archive,
+      // never mutates session state), so it's useful precisely when something is going wrong
+      // mid-turn — mirrors /history, /config, /debug being availableDuringRun.
+      availableDuringRun: true,
+      run: (ctx) => {
+        if (!ctx.dumpDebugSession) {
+          return {
+            notice: {
+              title: 'Debug dump unavailable',
+              lines: DEBUG_DUMP_UNAVAILABLE_LINES,
+              tone: 'warn',
+            },
+          };
+        }
+        const { archiveDir } = ctx.dumpDebugSession({
+          transcript: ctx.transcript ?? [],
+          config: ctx.resolvedConfig,
+          modelDisplayName: ctx.modelDisplayName,
+        });
+        return { notice: debugDumpNotice(archiveDir) };
+      },
     },
   ];
 }

--- a/packages/app/src/tui/tuiSessionModule.tsx
+++ b/packages/app/src/tui/tuiSessionModule.tsx
@@ -32,8 +32,9 @@ import { resolveAgentFactory } from '@gaunt-sloth/agent/core/resolveAgentFactory
 import { GthAbstractAgent } from '@gaunt-sloth/core/core/GthAbstractAgent.js';
 import type { SessionConfig } from '@gaunt-sloth/agent/modules/interactiveSessionModule.js';
 import type { BaseMessage } from '@langchain/core/messages';
+import { writeDebugDump } from '@gaunt-sloth/core/utils/debugDump.js';
 import { App } from '#src/tui/components/App.js';
-import { formatConfigSummary } from '#src/tui/slashCommands.js';
+import { formatConfigSummary, type DebugDumpInput } from '#src/tui/slashCommands.js';
 import type { PendingApproval, TuiAgent, TuiDebugCapture } from '#src/tui/types.js';
 import {
   collectMcpOverview,
@@ -90,6 +91,21 @@ function buildHistorySlashProps(config: GthConfig): HistorySlashProps {
   } catch {
     return {};
   }
+}
+
+/**
+ * GS2-46 — the real `/debug-dump` writer, injected into `<App>` the same way `historySearch` is:
+ * forwards the App-assembled input straight to the core writer, which does the actual fs I/O
+ * (mkdir + writeFileSync per file under the GLOBAL `~/.gsloth/debug-dumps/<timestamp>/`) plus
+ * gathers env/version info, the in-memory debugLog ring buffer, and best-effort git repo state
+ * itself. Dumped raw/unsanitized per this node's explicit scope (GS2-47 adds redaction later).
+ */
+function dumpDebugSession(input: DebugDumpInput): { archiveDir: string } {
+  return writeDebugDump({
+    transcript: input.transcript,
+    config: input.config,
+    modelDisplayName: input.modelDisplayName,
+  });
 }
 
 type StatusListener = (level: string, message: string) => void;
@@ -375,6 +391,8 @@ export async function createTuiSession(
         modelDisplayName={config.modelDisplayName}
         initialAutoApprove={runner.isSessionYolo()}
         configSummary={formatConfigSummary(config)}
+        resolvedConfig={config}
+        dumpDebugSession={dumpDebugSession}
         advisories={startupAdvisories}
         mcpFailures={mcpFailures}
         {...buildHistorySlashProps(config)}

--- a/packages/app/src/tui/types.ts
+++ b/packages/app/src/tui/types.ts
@@ -6,6 +6,7 @@ import type {
 } from '@gaunt-sloth/core/core/types.js';
 import type { TurnViewModel } from '#src/tui/viewModel.js';
 import type { CommandNoticeTone } from '#src/tui/components/CommandNotice.js';
+import type { DebugDumpInput } from '#src/tui/slashCommands.js';
 
 /**
  * One in-flight tool-approval request bridged from the runner into the mounted `<App>`
@@ -94,6 +95,20 @@ export interface TuiAppProps {
   historySummary?: string[];
   insightsSummary?: string[];
   historySearch?: (query: string) => string[];
+  /**
+   * GS2-46 — the resolved config (the live `GthConfig`), for `/debug-dump`. Kept `unknown` here
+   * (this component never inspects it — it just forwards it into `dumpDebugSession`) so the TUI
+   * layer stays decoupled from the core config type. Omitted by the fixture agent, where
+   * `/debug-dump` reports itself unavailable.
+   */
+  resolvedConfig?: unknown;
+  /**
+   * GS2-46 — fs-writing implementation for `/debug-dump` (an UNSANITIZED diagnostic archive:
+   * transcript, resolved config, env/version info, the in-memory debugLog ring buffer, and
+   * best-effort git repo state), wired to `packages/core/src/utils/debugDump.ts#writeDebugDump`
+   * the same way `historySearch` wires to the local history store. Omitted by the fixture agent.
+   */
+  dumpDebugSession?: (input: DebugDumpInput) => { archiveDir: string };
   /**
    * TUI-C19 — non-fatal startup advisories to surface persistently (currently the load-time
    * config-validation warnings — unknown keys, deprecated names — captured around `initConfig`).

--- a/packages/core/spec/debugDump.spec.ts
+++ b/packages/core/spec/debugDump.spec.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+// Real fs / real temp dir per the brief — only `os.homedir()` is mocked (pointed at a fresh
+// mkdtemp'd dir), so `ensureGlobalGslothDir()` (and therefore the archive path construction it
+// drives) is exercised for real, without touching the developer's actual `~/.gsloth`. `vi.hoisted`
+// avoids a TDZ error: this file also statically imports `tmpdir` from 'node:os', so the mock
+// factory can run during that very import, before a plain top-level `const` would be initialized.
+const { homedirMock } = vi.hoisted(() => ({ homedirMock: vi.fn() }));
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, homedir: homedirMock };
+});
+
+describe('utils/debugDump', () => {
+  let homeDir: string;
+  let notGitDir: string;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    homeDir = mkdtempSync(resolve(tmpdir(), 'gsloth-debugdump-home-'));
+    notGitDir = mkdtempSync(resolve(tmpdir(), 'gsloth-debugdump-notgit-'));
+    homedirMock.mockReturnValue(homeDir);
+  });
+
+  afterEach(() => {
+    rmSync(homeDir, { recursive: true, force: true });
+    rmSync(notGitDir, { recursive: true, force: true });
+  });
+
+  it('writes transcript, config, env and debug-log files under the GLOBAL ~/.gsloth/debug-dumps/<timestamp>/', async () => {
+    const { writeDebugDump } = await import('#src/utils/debugDump.js');
+    const { debugLog } = await import('#src/utils/debugUtils.js');
+    debugLog('GS2-46 debugDump writer test marker');
+
+    const transcript = [
+      { kind: 'user', text: 'hello' },
+      { kind: 'assistant', text: 'hi there' },
+    ];
+    const config = { modelDisplayName: 'test-model', agent: { backend: 'lean' } };
+
+    const { archiveDir } = writeDebugDump({
+      transcript,
+      config,
+      modelDisplayName: 'test-model',
+      cwd: notGitDir, // not a git repo — exercises the "omit git-state" path
+    });
+
+    // Archive lives under the GLOBAL dir, not some cwd-relative one.
+    expect(archiveDir).toContain(resolve(homeDir, '.gsloth', 'debug-dumps'));
+    expect(existsSync(archiveDir)).toBe(true);
+
+    const transcriptOut = JSON.parse(readFileSync(resolve(archiveDir, 'transcript.json'), 'utf8'));
+    expect(transcriptOut).toEqual(transcript);
+
+    const configOut = JSON.parse(readFileSync(resolve(archiveDir, 'config.json'), 'utf8'));
+    expect(configOut).toEqual(config);
+
+    const envOut = JSON.parse(readFileSync(resolve(archiveDir, 'env.json'), 'utf8'));
+    expect(envOut).toMatchObject({
+      nodeVersion: process.version,
+      platform: process.platform,
+      model: 'test-model',
+    });
+    expect(envOut.gthVersion).toBeDefined();
+
+    const debugLogOut = readFileSync(resolve(archiveDir, 'debug-log.txt'), 'utf8');
+    expect(debugLogOut).toContain('GS2-46 debugDump writer test marker');
+
+    // Not a git repo → git-state.json must be entirely omitted, not written empty/erroring.
+    expect(existsSync(resolve(archiveDir, 'git-state.json'))).toBe(false);
+  });
+
+  it('includes git-state.json (branch/remote/dirty) when run inside a git repo', async () => {
+    const { writeDebugDump } = await import('#src/utils/debugDump.js');
+
+    // This test file itself runs from inside the gaunt-sloth git repo checkout.
+    const { archiveDir } = writeDebugDump({
+      transcript: [],
+      config: {},
+      modelDisplayName: 'test-model',
+      cwd: process.cwd(),
+    });
+
+    const gitStatePath = resolve(archiveDir, 'git-state.json');
+    expect(existsSync(gitStatePath)).toBe(true);
+    const gitState = JSON.parse(readFileSync(gitStatePath, 'utf8'));
+    expect(typeof gitState.branch).toBe('string');
+    expect(gitState.branch.length).toBeGreaterThan(0);
+    expect(typeof gitState.dirty).toBe('boolean');
+  });
+
+  it('never throws on a circular / non-JSON-safe config (e.g. a live LLM client object)', async () => {
+    const { writeDebugDump } = await import('#src/utils/debugDump.js');
+
+    const circular: any = { modelDisplayName: 'test-model' };
+    circular.self = circular; // circular reference
+    circular.doSomething = function namedFn() {}; // a function, like a live client's methods
+
+    expect(() =>
+      writeDebugDump({
+        transcript: [],
+        config: circular,
+        modelDisplayName: 'test-model',
+        cwd: notGitDir,
+      })
+    ).not.toThrow();
+  });
+
+  it('writes a distinct, filesystem-safe timestamped directory on each call', async () => {
+    const { writeDebugDump } = await import('#src/utils/debugDump.js');
+
+    const first = writeDebugDump({ transcript: [], config: {}, cwd: notGitDir });
+    const second = writeDebugDump({ transcript: [], config: {}, cwd: notGitDir });
+
+    expect(first.archiveDir).not.toBe(second.archiveDir);
+    // Filesystem-safe: no `:` characters (from the ISO timestamp) in the path.
+    expect(first.archiveDir.includes(':')).toBe(false);
+  });
+});

--- a/packages/core/spec/debugUtils.spec.ts
+++ b/packages/core/spec/debugUtils.spec.ts
@@ -142,4 +142,78 @@ describe('debugUtils', () => {
       );
     });
   });
+
+  // GS2-46: the in-memory debugLog ring buffer that `/debug-dump` (and later GS2-48's crash
+  // handler) reads. It must be populated by every debugLog* variant regardless of whether
+  // debugEnabled (the on-disk gate) is on — assertions here are delta-based (buffer length
+  // before/after, or unique markers) because the module-level buffer is shared across `it`s
+  // within this file (dynamic import resolves the same cached module instance).
+  describe('getDebugLogBuffer', () => {
+    it('is populated by debugLog even when debug logging is disabled', async () => {
+      const { initDebugLogging, debugLog, getDebugLogBuffer } =
+        await import('#src/utils/debugUtils.js');
+
+      initDebugLogging(false); // on-disk logging OFF
+      const before = getDebugLogBuffer().length;
+      debugLog('GS2-46 marker: buffered-without-debugEnabled');
+      const after = getDebugLogBuffer();
+
+      expect(fsMock.appendFileSync).not.toHaveBeenCalled();
+      expect(after.length).toBe(before + 1);
+      expect(after[after.length - 1]).toContain('GS2-46 marker: buffered-without-debugEnabled');
+    });
+
+    it('debugLogMultiline, debugLogObject and debugLogError all buffer regardless of debugEnabled', async () => {
+      const {
+        initDebugLogging,
+        debugLogMultiline,
+        debugLogObject,
+        debugLogError,
+        getDebugLogBuffer,
+      } = await import('#src/utils/debugUtils.js');
+
+      initDebugLogging(false);
+      const before = getDebugLogBuffer().length;
+
+      debugLogMultiline('GS2-46 Multiline', 'body line');
+      debugLogObject('GS2-46 Object', { foo: 'bar' });
+      debugLogError('GS2-46 context', new Error('boom'));
+
+      const after = getDebugLogBuffer();
+      expect(after.length).toBeGreaterThan(before);
+      expect(after.some((l) => l.includes('=== GS2-46 Multiline ==='))).toBe(true);
+      expect(after.some((l) => l.includes('=== GS2-46 Object ==='))).toBe(true);
+      expect(after.some((l) => l.includes("foo: 'bar'"))).toBe(true);
+      expect(after.some((l) => l.includes('❌ Error in GS2-46 context:'))).toBe(true);
+    });
+
+    it('caps the buffer at 1000 entries, evicting the oldest first', async () => {
+      const { initDebugLogging, debugLog, getDebugLogBuffer } =
+        await import('#src/utils/debugUtils.js');
+      initDebugLogging(false); // independent of test order — this test only cares about the buffer
+
+      for (let i = 0; i < 1005; i++) {
+        debugLog(`GS2-46 ring-test entry ${String(i).padStart(5, '0')}`);
+      }
+
+      const buffer = getDebugLogBuffer();
+      expect(buffer.length).toBeLessThanOrEqual(1000);
+      expect(buffer.length).toBe(1000);
+      // The most recent entries must have survived the cap.
+      expect(buffer[buffer.length - 1]).toContain('GS2-46 ring-test entry 01004');
+      // The earliest entries pushed in this test must have been evicted.
+      expect(buffer.some((l) => l.includes('GS2-46 ring-test entry 00000'))).toBe(false);
+    });
+
+    it('returns a copy — mutating the result does not affect the live buffer', async () => {
+      const { debugLog, getDebugLogBuffer } = await import('#src/utils/debugUtils.js');
+
+      debugLog('GS2-46 copy-safety marker');
+      const snapshot = getDebugLogBuffer();
+      const originalLength = snapshot.length;
+      snapshot.push('mutated externally');
+
+      expect(getDebugLogBuffer().length).toBe(originalLength);
+    });
+  });
 });

--- a/packages/core/src/utils/debugDump.ts
+++ b/packages/core/src/utils/debugDump.ts
@@ -1,0 +1,146 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { inspect } from 'node:util';
+import { ensureGlobalGslothDir } from '#src/utils/globalConfigUtils.js';
+import { getSlothVersion } from '#src/utils/systemUtils.js';
+import { getDebugLogBuffer } from '#src/utils/debugUtils.js';
+
+/**
+ * GS2-46 — `/debug-dump`: a live-session diagnostic archive, written UNSANITIZED (that's GS2-47's
+ * job on top of this). The user typed the command themselves, mid-session, knowingly, so the
+ * caller (the slash command) is responsible for the loud "may contain secrets" warning — this
+ * module only writes the files.
+ */
+
+/** Input to {@link writeDebugDump}. `transcript`/`config` are dumped as-is (raw, unsanitized). */
+export interface WriteDebugDumpInput {
+  /** The full transcript (all turns, tool calls + results). Opaque — serialized as JSON. */
+  transcript: unknown;
+  /** The resolved effective config (the live `GthConfig`). Opaque — serialized as JSON. */
+  config: unknown;
+  /** Model display name, already resolved by the caller. */
+  modelDisplayName?: string;
+  /**
+   * Working directory for git-state collection. Defaults to `process.cwd()`; overridable for
+   * tests so the "not a git repo" / "inside a git repo" paths are both exercisable without
+   * depending on where the test runner happens to execute.
+   */
+  cwd?: string;
+}
+
+export interface WriteDebugDumpResult {
+  /** The absolute path to the archive directory just written. */
+  archiveDir: string;
+}
+
+interface GitState {
+  branch: string;
+  remote?: string;
+  dirty: boolean;
+}
+
+/**
+ * Best-effort git repo state (branch/remote/dirty). Uses `execFileSync` — NOT the existing
+ * `execAsync` helper in systemUtils.ts (a promisified wrapper used elsewhere for `gh` calls) —
+ * because `SlashCommand.run()` is fully synchronous (no Promise support in the TUI's registry or
+ * dispatcher). Fails soft: any failure (not inside a repo, `git` missing, a detached/bare repo
+ * with no remote, etc.) returns `undefined` rather than throwing, so the command never errors —
+ * the git-state file is simply omitted from the archive.
+ */
+function collectGitState(cwd: string): GitState | undefined {
+  try {
+    const run = (args: string[]): string =>
+      execFileSync('git', args, {
+        cwd,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+
+    const branch = run(['rev-parse', '--abbrev-ref', 'HEAD']);
+
+    let remote: string | undefined;
+    try {
+      remote = run(['remote', 'get-url', 'origin']);
+    } catch {
+      remote = undefined; // no `origin` remote configured — not fatal, just omit it
+    }
+
+    const status = run(['status', '--porcelain']);
+    return { branch, remote, dirty: status.length > 0 };
+  } catch {
+    return undefined; // not inside a git repo (or git unavailable) — omit the file entirely
+  }
+}
+
+/**
+ * Serialize a value as pretty JSON, tolerating the non-JSON-safe shapes real session state can
+ * contain (e.g. the resolved `GthConfig.llm` is a live LangChain client, not plain data):
+ * functions/bigints are stringified and circular references are broken rather than throwing.
+ * Falls back to `util.inspect` if `JSON.stringify` still fails for some other reason, so writing
+ * the dump can never throw partway through the archive.
+ */
+function safeStringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+  try {
+    return JSON.stringify(
+      value,
+      (_key, val) => {
+        if (typeof val === 'function') return `[Function: ${val.name || 'anonymous'}]`;
+        if (typeof val === 'bigint') return val.toString();
+        if (val && typeof val === 'object') {
+          if (seen.has(val as object)) return '[Circular]';
+          seen.add(val as object);
+        }
+        return val;
+      },
+      2
+    );
+  } catch {
+    return inspect(value, { showHidden: false, depth: 5, colors: false });
+  }
+}
+
+/**
+ * Write one timestamped `/debug-dump` archive under the GLOBAL `~/.gsloth/debug-dumps/<timestamp>/`
+ * (via `ensureGlobalGslothDir()` — mirrors how `resolveHistoryDbPath()` builds its path under the
+ * same dir — NOT the per-project cwd-relative helper of the same name elsewhere in this codebase).
+ * Contains: the full transcript, the resolved config, env/version info, the in-memory debugLog
+ * ring buffer, and (best-effort) git repo state. Everything is dumped raw/unsanitized — this node
+ * ships deliberately unsanitized (GS2-47 adds redaction on top later); the caller is responsible
+ * for surfacing the "may contain secrets" warning to the user.
+ */
+export function writeDebugDump(input: WriteDebugDumpInput): WriteDebugDumpResult {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const archiveDir = resolve(ensureGlobalGslothDir(), 'debug-dumps', timestamp);
+  mkdirSync(archiveDir, { recursive: true });
+
+  writeFileSync(resolve(archiveDir, 'transcript.json'), safeStringify(input.transcript), 'utf8');
+  writeFileSync(resolve(archiveDir, 'config.json'), safeStringify(input.config), 'utf8');
+
+  // getSlothVersion() reads the installed package.json via the install dir set at CLI startup
+  // (setEntryPoint); guarded so a dump can never fail just because that wasn't wired (e.g. an
+  // unusual embedding), falling back to 'unknown'.
+  let gthVersion: string;
+  try {
+    gthVersion = getSlothVersion();
+  } catch {
+    gthVersion = 'unknown';
+  }
+  const envInfo = {
+    gthVersion,
+    nodeVersion: process.version,
+    platform: process.platform,
+    model: input.modelDisplayName ?? 'unknown',
+  };
+  writeFileSync(resolve(archiveDir, 'env.json'), safeStringify(envInfo), 'utf8');
+
+  writeFileSync(resolve(archiveDir, 'debug-log.txt'), getDebugLogBuffer().join('\n'), 'utf8');
+
+  const gitState = collectGitState(input.cwd ?? process.cwd());
+  if (gitState) {
+    writeFileSync(resolve(archiveDir, 'git-state.json'), safeStringify(gitState), 'utf8');
+  }
+
+  return { archiveDir };
+}

--- a/packages/core/src/utils/debugUtils.ts
+++ b/packages/core/src/utils/debugUtils.ts
@@ -6,6 +6,33 @@ const DEBUG_LOG_FILE = 'gaunt-sloth.log';
 let debugEnabled = false;
 
 /**
+ * GS2-46 — bounded in-memory ring buffer of debug-log lines, populated by every `debugLog*`
+ * variant UNCONDITIONALLY (independent of `debugEnabled`, which only gates the on-disk write
+ * below). This is deliberately always-on and forward-looking: GS2-48 (crash handler) expects
+ * "the last-N debugLog buffer lines already held in memory" to exist regardless of whether
+ * `config.debugLog` was ever turned on for the session, and `/debug-dump` (GS2-46) surfaces it
+ * verbatim. Capped so a long session can't grow this without bound.
+ */
+const DEBUG_LOG_BUFFER_MAX = 1000;
+const debugLogBuffer: string[] = [];
+
+/** Push one formatted line into the ring buffer, evicting the oldest entry once at capacity. */
+function pushToDebugLogBuffer(entry: string): void {
+  debugLogBuffer.push(entry);
+  if (debugLogBuffer.length > DEBUG_LOG_BUFFER_MAX) {
+    debugLogBuffer.shift();
+  }
+}
+
+/**
+ * GS2-46 — read the current debug-log ring buffer (oldest first). Returns a copy so callers
+ * (e.g. the `/debug-dump` writer) can't mutate the live buffer.
+ */
+export function getDebugLogBuffer(): string[] {
+  return [...debugLogBuffer];
+}
+
+/**
  * Initialize debug logging based on config
  */
 export function initDebugLogging(enabled: boolean): void {
@@ -30,16 +57,18 @@ export function initDebugLogging(enabled: boolean): void {
 }
 
 /**
- * Log a debug message to the log file
+ * Log a debug message. Always pushed into the in-memory ring buffer (GS2-46); only appended to
+ * the on-disk log file when debug logging is enabled.
  */
 export function debugLog(message: string): void {
+  const timestamp = new Date().toISOString();
+  const logEntry = `[${timestamp}] ${message}`;
+  pushToDebugLogBuffer(logEntry);
+
   if (!debugEnabled) return;
 
-  const timestamp = new Date().toISOString();
-  const logEntry = `[${timestamp}] ${message}\n`;
-
   try {
-    appendFileSync(resolve(DEBUG_LOG_FILE), logEntry, 'utf8');
+    appendFileSync(resolve(DEBUG_LOG_FILE), `${logEntry}\n`, 'utf8');
   } catch (error) {
     // Ignore logging errors to prevent breaking the main flow
     console.error('Failed to write to debug log:', error);
@@ -47,22 +76,20 @@ export function debugLog(message: string): void {
 }
 
 /**
- * Log multiple lines with proper formatting
+ * Log multiple lines with proper formatting. Always buffered (GS2-46); delegates to `debugLog`
+ * for the on-disk gating.
  */
 export function debugLogMultiline(title: string, content: string): void {
-  if (!debugEnabled) return;
-
   debugLog(`=== ${title} ===`);
   debugLog(content);
   debugLog(`=== End ${title} ===\n`);
 }
 
 /**
- * Log an object using Node.js inspect with reasonable depth
+ * Log an object using Node.js inspect with reasonable depth. Always buffered (GS2-46); delegates
+ * to `debugLogMultiline`/`debugLog` for the on-disk gating.
  */
 export function debugLogObject(title: string, obj: unknown): void {
-  if (!debugEnabled) return;
-
   try {
     // Use Node.js inspect with reasonable depth and no colors for log files
     const formatted = inspect(obj, { showHidden: false, depth: 3, colors: false });
@@ -73,11 +100,10 @@ export function debugLogObject(title: string, obj: unknown): void {
 }
 
 /**
- * Log error with stack trace
+ * Log error with stack trace. Always buffered (GS2-46); delegates to `debugLog` for the on-disk
+ * gating.
  */
 export function debugLogError(context: string, error: unknown): void {
-  if (!debugEnabled) return;
-
   debugLog(`❌ Error in ${context}:`);
   if (error instanceof Error) {
     debugLog(`  Message: ${error.message}`);


### PR DESCRIPTION
## Summary
- Adds a `/debug-dump` slash command that writes a timestamped archive under `~/.gsloth/debug-dumps/<timestamp>/` containing the full transcript, resolved config, env/version info, the in-memory debugLog buffer, and best-effort git repo state
- Adds a bounded (1000-entry) in-memory ring buffer to `debugUtils.ts`, populated unconditionally regardless of `debugEnabled` (sets up GS2-48's crash handler, which expects this buffer to already exist)
- Deliberately unsanitized v1 — prints a loud warning that the archive may contain secrets; redaction is GS2-47's job

## Test plan
- [x] `npm run build` — zero tsc errors across all workspace packages
- [x] `npx vitest run packages/core packages/app` — 1031/1031 passing
- [x] `npm run lint` — clean
- [x] Reviewed for spec compliance + code quality (see ticket ledger) — both clean, ship as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)