### PR TITLE
EXT-66: make the rating budget the user's, and stop a timeout reading as a judgement

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -686,7 +686,17 @@ sweep:
 
 with `.gsloth/.gsloth-settings/{haiku,flash,gemma}/.gsloth.config.json` each declaring its own `type` and `model`.
 
-One thing to check before believing a cross-provider comparison: **a rating call that times out is reported as `destructive`**, so a slow provider's column can read as agreement when it is really the gate's fail-closed default. The per-case `rationale` says which — a reason of *"could not evaluate"* is a call that did not finish, not a judgement.
+One thing to check before believing a cross-provider comparison: **a rating call that times out is still reported as `destructive`**, so a slow provider's column can read as agreement when it is really the gate's fail-closed default. The per-case `rationale` is what distinguishes them — a timeout now says *"the auto-rater did not answer within Nms"* and names the budget, where a real judgement explains the command.
+
+If that is what you are seeing, raise the budget rather than reading the column. One rating call gets 30 seconds by default, which is a hosted-model number; a 12B over Ollama measured 6s to nearly two minutes on the same commands, and the harder the command the longer it thought — so the default clips exactly the cases worth comparing. It is a normal config key, so a sweep axis sets it like any other:
+
+```yaml
+target: { type: rater, rung: full-auto }
+sweep:
+  rater:
+    - { config: { approvals: { mode: full-auto, rater: haiku } } }
+    - { config: { approvals: { mode: full-auto, rater: local, raterTimeoutMs: 120000 } } }
+```
 
 **Sweeping `model:` moves the judge too.** By default `judge:` rubrics are graded by the SUT's own model, so a model axis changes the grader along with the thing graded and the comparison's `pass rate` row is no longer comparable across cells. Set `judge_profile:` (or `--judge`) to pin the grader to one model whenever you sweep `model:` on a suite that uses rubrics.
 

--- a/docs/guides/shell-tool-and-approvals.md
+++ b/docs/guides/shell-tool-and-approvals.md
@@ -57,6 +57,12 @@ Anything the rater cannot assess lands on **destructive** and says so; it never 
 Pushing and publishing to somewhere your project already configures — `git push`, `npm publish`,
 `docker push` — is ordinary work: the rater may well ask about it, but it never ends the run.
 
+**Read the sentence, not just the word in brackets.** Because "could not assess" also lands on
+**destructive**, the bracketed word alone cannot tell you whether a model looked at the command and
+judged it, or whether the gate never got an answer. The reason says which — "could not assess this
+command: the auto-rater did not answer within 30000ms" is the gate giving up, not a finding about
+your command. If you see that one, the fix is a bigger budget (below), not a safer command.
+
 ### A command that names a host always asks
 
 When one of the usual network tools — `curl`, `wget`, `ssh`, `scp`, `rsync`, `nc`, `aws`, `git
@@ -94,6 +100,31 @@ does fire, no model opinion can wave the command through.
 
 The rater is only as good as the model behind it. On a small or local model, prefer the `write` rung
 (below) or point the rater at a stronger model with `approvals.rater`.
+
+### Give a local rater enough time
+
+One rating call gets **30 seconds** by default, and that is a hosted-model number. A local model is
+slower, and — awkwardly — the harder the command, the longer it thinks, so a fixed budget cuts off
+exactly the commands that most needed rating. Measured on a 12B over Ollama, the same set of
+commands took anywhere from 6 seconds to nearly two minutes.
+
+When the rater runs out of time the command is escalated rather than approved, which is safe but is
+also the opposite of what `auto-safe` and `full-auto` are for: you end up being asked about
+everything, and nothing tells you why. So gth says so, once per occurrence, and you can raise the
+budget:
+
+```json
+{
+  "approvals": {
+    "mode": "full-auto",
+    "rater": "local-rater",
+    "raterTimeoutMs": 120000
+  }
+}
+```
+
+It is a number you set rather than one gth guesses from the provider, because a guess about your
+hardware that turns out wrong fails quietly.
 
 To have the agent run tests *without* any of this, give it the fixed `run_tests` dev-command tool:
 you set the exact command, and because there is nothing for the model to choose, it runs with **no

--- a/packages/batch/spec/raterTarget.spec.ts
+++ b/packages/batch/spec/raterTarget.spec.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   FAIL_CLOSED_VERDICT,
+  failClosedVerdict,
   RATER_OUTCOMES,
   mapVerdictToAction,
 } from '@gaunt-sloth/core/core/shell/rater.js';
@@ -234,8 +235,14 @@ describe('buildRaterClassifier (BATCH-25 Half B — the `rater` target)', () => 
       expect(invoke).toHaveBeenCalledTimes(1);
       // Core's own fail-closed verdict, passed through — this package never invents one.
       expect(outcome.label).toBe(FAIL_CLOSED_VERDICT.outcome);
-      expect(outcome.rationale).toContain(FAIL_CLOSED_VERDICT.reason);
+      expect(outcome.rationale).toContain(failClosedVerdict('timeout', 5).reason);
       expect(outcome.modelCalls).toBe(1);
+      // EXT-66 — a suite reading this column has to be able to tell a rating from a default. The
+      // label is `destructive` either way (fail-closed is correct), so the RATIONALE is the only
+      // place the distinction can live, and an eval that reports the escalation as coverage
+      // without reading it is measuring the timeout. The EXT-62 sweep did exactly that.
+      expect(outcome.rationale).toContain('did not answer within');
+      expect(outcome.rationale).toContain('approvals.raterTimeoutMs');
     });
   });
 

--- a/packages/core/schema/gsloth-config.schema.json
+++ b/packages/core/schema/gsloth-config.schema.json
@@ -436,6 +436,11 @@
               "items": {
                 "type": "string"
               }
+            },
+            "raterTimeoutMs": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
             }
           }
         }
@@ -714,6 +719,11 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "raterTimeoutMs": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 9007199254740991
                     }
                   }
                 }
@@ -972,6 +982,11 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "raterTimeoutMs": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 9007199254740991
                     }
                   }
                 }
@@ -1221,6 +1236,11 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "raterTimeoutMs": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 9007199254740991
                     }
                   }
                 }
@@ -1450,6 +1470,11 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "raterTimeoutMs": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 9007199254740991
                     }
                   }
                 }
@@ -1679,6 +1704,11 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "raterTimeoutMs": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 9007199254740991
                     }
                   }
                 }
@@ -1908,6 +1938,11 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "raterTimeoutMs": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 9007199254740991
                     }
                   }
                 }
@@ -2137,6 +2172,11 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "raterTimeoutMs": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 9007199254740991
                     }
                   }
                 }

--- a/packages/core/spec/GthAgentRunner.spec.ts
+++ b/packages/core/spec/GthAgentRunner.spec.ts
@@ -594,6 +594,130 @@ describe('GthAgentRunner', () => {
       expect(runner.getSessionApprovals().rung).toBe('write');
     });
 
+    /**
+     * EXT-66 — the rater timeout is part of the resolved posture, and a call that runs out of it is
+     * SAID OUT LOUD rather than laundered into the escalation.
+     *
+     * Both halves matter and neither is cosmetic. The budget had no config key at all, so a local
+     * rater — measured at 6.0s–114.7s per call on `gemma4:12b` — was cut off by a 30s constant it
+     * could not reach, and `full-auto` drifted toward escalating everything, which is the failure
+     * the rung exists to prevent. And because the timeout produced a verdict byte-identical to a
+     * real `destructive` judgement, every layer reported success while it happened: the only
+     * symptom was the gate becoming mysteriously more talkative.
+     */
+    it('carries the rater timeout into the resolved posture', async () => {
+      resolveRaterModelMock.mockResolvedValue({ withStructuredOutput: vi.fn() } as any);
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      await runner.init('code', {
+        ...mockConfig,
+        approvals: { mode: 'full-auto', rater: 'safety-rater', raterTimeoutMs: 120_000 },
+      } as unknown as typeof mockConfig);
+      expect(runner.getSessionApprovals().raterTimeoutMs).toBe(120_000);
+    });
+
+    it('leaves the rater timeout undefined when config does not set one', async () => {
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      await runner.init('code', {
+        ...mockConfig,
+        approvals: 'full-auto',
+      } as unknown as typeof mockConfig);
+      // Undefined, not 30000: the default belongs to the rater, so the effective-config snapshot
+      // does not churn and an unset key stays visibly unset.
+      expect(runner.getSessionApprovals().raterTimeoutMs).toBeUndefined();
+    });
+
+    /**
+     * EXT-66 — the PER-COMMAND budget, and the reason the runner passes the timeout explicitly
+     * rather than letting `rateShellCommand` resolve it alone.
+     *
+     * `rateShellCommand` resolves `approvals` with no command, so it can only ever see the ROOT
+     * value. A `commands.code.approvals.raterTimeoutMs` reaches it exclusively through the runner,
+     * which resolved the posture WITH the command. Found by deleting the runner's pass-through and
+     * watching the suite stay green — the two paths agree on the root value, so nothing else here
+     * could tell them apart.
+     */
+    it('honours a per-command rater timeout, which only the runner can resolve', async () => {
+      const invoke = vi.fn(() => new Promise(() => {}));
+      resolveRaterModelMock.mockResolvedValue({
+        withStructuredOutput: () => ({ invoke }),
+      } as any);
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      mockAgent.stream.mockResolvedValue({
+        async *[Symbol.asyncIterator]() {
+          yield 'working';
+        },
+      });
+      (mockAgent as any).getPendingToolInterrupts = vi
+        .fn()
+        .mockResolvedValueOnce([{ name: 'run_shell_command', args: { command: 'ls -la' } }])
+        .mockResolvedValueOnce([]);
+      (mockAgent as any).streamResume = vi.fn().mockResolvedValue({
+        async *[Symbol.asyncIterator]() {
+          yield ' done';
+        },
+      });
+      await runner.init('code', {
+        ...mockConfig,
+        streamOutput: true,
+        // Root says a budget long enough to hang the test; the per-command value is the one that
+        // must win, exactly as the rung does.
+        approvals: { mode: 'full-auto', rater: 'slow-rater', raterTimeoutMs: 900_000 },
+        commands: {
+          code: { approvals: { mode: 'full-auto', rater: 'slow-rater', raterTimeoutMs: 6 } },
+        },
+      } as unknown as typeof mockConfig);
+      runner.setToolApprovalCallback(vi.fn().mockResolvedValue({ type: 'approve' }));
+
+      await runner.processMessages([new HumanMessage('run ls')]);
+
+      const said = statusUpdateCallback.mock.calls.map(([, message]) => String(message));
+      const notice = said.find((m) => m.includes('did not answer in time'));
+      expect(
+        notice,
+        `expected the per-command budget to apply; saw: ${JSON.stringify(said)}`
+      ).toBeDefined();
+      expect(notice).toContain('6ms');
+    });
+
+    it('warns the user when the rater runs out of time, instead of escalating silently', async () => {
+      // A rater model that never answers, with a 5ms budget — the shape of a local model on a
+      // hard command, compressed.
+      resolveRaterModelMock.mockResolvedValue({
+        withStructuredOutput: () => ({ invoke: () => new Promise(() => {}) }),
+      } as any);
+      const runner = new GthAgentRunner(statusUpdateCallback);
+      mockAgent.stream.mockResolvedValue({
+        async *[Symbol.asyncIterator]() {
+          yield 'working';
+        },
+      });
+      (mockAgent as any).getPendingToolInterrupts = vi
+        .fn()
+        .mockResolvedValueOnce([{ name: 'run_shell_command', args: { command: 'ls -la' } }])
+        .mockResolvedValueOnce([]);
+      (mockAgent as any).streamResume = vi.fn().mockResolvedValue({
+        async *[Symbol.asyncIterator]() {
+          yield ' done';
+        },
+      });
+      await runner.init('code', {
+        ...mockConfig,
+        streamOutput: true,
+        approvals: { mode: 'full-auto', rater: 'slow-rater', raterTimeoutMs: 5 },
+      } as unknown as typeof mockConfig);
+      runner.setToolApprovalCallback(vi.fn().mockResolvedValue({ type: 'approve' }));
+
+      await runner.processMessages([new HumanMessage('run ls')]);
+
+      const said = statusUpdateCallback.mock.calls.map(([, message]) => String(message));
+      const notice = said.find((m) => m.includes('did not answer in time'));
+      expect(notice, `expected a timeout notice among: ${JSON.stringify(said)}`).toBeDefined();
+      expect(notice).toContain('5ms');
+      expect(notice).toContain('approvals.raterTimeoutMs');
+      // It must not claim the command was judged — that is the whole distinction.
+      expect(notice).not.toMatch(/\bdestructive\b/);
+    });
+
     it('init seeds the whole posture (rung + rater profile + declared lists) from config', async () => {
       resolveRaterModelMock.mockResolvedValue({ withStructuredOutput: vi.fn() } as any);
       const runner = new GthAgentRunner(statusUpdateCallback);

--- a/packages/core/spec/GthLeanShellApprovalGate.spec.ts
+++ b/packages/core/spec/GthLeanShellApprovalGate.spec.ts
@@ -33,7 +33,12 @@ import type {
 // CFG-26 rater — scripted per test so the rater layer is observable without an LLM call.
 const rateShellCommandMock = vi.fn();
 const mapVerdictToActionMock = vi.fn();
-vi.mock('#src/core/shell/rater.js', () => ({
+// EXT-66 — the two decision functions are stubbed; everything else stays REAL via importOriginal,
+// including `isRaterTimeout` and `RATER_DEFAULT_TIMEOUT_MS`, which the runner now consults to tell
+// "the gate gave up" from "the model judged". Listing exports by hand is what made this mock go
+// stale the moment the module grew one.
+vi.mock('#src/core/shell/rater.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('#src/core/shell/rater.js')>()),
   rateShellCommand: rateShellCommandMock,
   mapVerdictToAction: mapVerdictToActionMock,
 }));

--- a/packages/core/spec/configSchema.spec.ts
+++ b/packages/core/spec/configSchema.spec.ts
@@ -581,6 +581,7 @@ describe('config schema (GS2-1 B1)', () => {
             'deny',
             'mode',
             'rater',
+            'raterTimeoutMs',
           ]);
           // A refinement has no JSON Schema representation; nothing of that shape may appear.
           expect(JSON.stringify(approvals)).not.toContain('not');

--- a/packages/core/spec/shellRater.spec.ts
+++ b/packages/core/spec/shellRater.spec.ts
@@ -8,6 +8,10 @@ import {
   buildRaterSystemPrompt,
   COULD_NOT_ASSESS_PREFIX,
   FAIL_CLOSED_VERDICT,
+  failClosedVerdict,
+  RATER_DEFAULT_TIMEOUT_MS,
+  isFailClosed,
+  isRaterTimeout,
   foldHomePath,
   hasScriptEnvLeakRisk,
   isBelowDestructiveFloor,
@@ -528,9 +532,11 @@ describe('rateShellCommand', () => {
       throw new Error('boom');
     });
     const result = await rateShellCommand('ls -la', CONFIG, { model });
-    expect(result).toEqual(FAIL_CLOSED_VERDICT);
+    expect(result).toEqual(failClosedVerdict('threw'));
     expect(result.outcome).toBe('destructive');
     expect(result.reason).toContain(COULD_NOT_ASSESS_PREFIX);
+    expect(isFailClosed(result)).toBe(true);
+    expect(isRaterTimeout(result), 'a throw is not a timeout').toBe(false);
   });
 
   it('never fails closed to `attack` or `catastrophic` — a failure to assess must not halt', () => {
@@ -548,31 +554,41 @@ describe('rateShellCommand', () => {
   it('fails closed when the model returns the RETIRED `exfiltration` outcome', async () => {
     const { model } = fakeModel(() => ({ outcome: 'exfiltration', reason: 'sends a key' }));
     expect(await rateShellCommand('cat ~/.ssh/id_rsa', CONFIG, { model })).toEqual(
-      FAIL_CLOSED_VERDICT
+      failClosedVerdict('unparseable')
     );
   });
 
   it('fails closed when the model returns garbage', async () => {
     const { model } = fakeModel(() => ({ not: 'a verdict' }));
-    expect(await rateShellCommand('ls -la', CONFIG, { model })).toEqual(FAIL_CLOSED_VERDICT);
+    expect(await rateShellCommand('ls -la', CONFIG, { model })).toEqual(
+      failClosedVerdict('unparseable')
+    );
   });
 
   it('fails closed when the model returns a RETIRED four-tier verdict', async () => {
     const { model } = fakeModel(() => ({ tier: 'caution', reason: 'ok' }));
-    expect(await rateShellCommand('ls -la', CONFIG, { model })).toEqual(FAIL_CLOSED_VERDICT);
+    expect(await rateShellCommand('ls -la', CONFIG, { model })).toEqual(
+      failClosedVerdict('unparseable')
+    );
   });
 
   it('fails closed when the model is unusable', async () => {
     expect(
       await rateShellCommand('ls -la', CONFIG, { model: {} as unknown as BaseChatModel })
-    ).toEqual(FAIL_CLOSED_VERDICT);
+    ).toEqual(failClosedVerdict('no-model'));
   });
 
   it('fails closed on timeout', async () => {
     const { model } = fakeModel(() => new Promise(() => {})); // never resolves
-    expect(await rateShellCommand('ls -la', CONFIG, { model, timeoutMs: 5 })).toEqual(
-      FAIL_CLOSED_VERDICT
-    );
+    const result = await rateShellCommand('ls -la', CONFIG, { model, timeoutMs: 5 });
+    expect(result).toEqual(failClosedVerdict('timeout', 5));
+    // EXT-66 — the point of the split. Before it, this verdict was byte-identical to the one a
+    // model returns after looking at the command and calling it destructive, so an eval column and
+    // a session summary both read a gate that gave up as a gate that worked.
+    expect(result.outcome, 'still fails CLOSED').toBe('destructive');
+    expect(isRaterTimeout(result)).toBe(true);
+    expect(result.reason).toContain('5ms');
+    expect(result.reason).toContain('approvals.raterTimeoutMs');
   });
 
   it('defaults the rater model to config.llm', async () => {
@@ -957,5 +973,97 @@ describe('mapVerdictToAction (CFG-28: 4 outcomes × 5 rungs)', () => {
         expect(isBelowDestructiveFloor(outcome)).toBe(false);
       }
     });
+  });
+});
+
+/**
+ * EXT-66 — the timeout is a number the user owns, and a timeout is not a judgement.
+ *
+ * Two defects, measured 2026-07-31 while sweeping the EXT-62 anchoring across three raters.
+ * `RATER_DEFAULT_TIMEOUT_MS` was a hardcoded 30s with no config key, which is a hosted-model
+ * number: `gemma4:12b` over a local GPU took 6.0s–114.7s on the same corpus and was cut off on 3
+ * of 18 calls in one run and 9 of 17 in the next. And every one of those cut-offs was reported as
+ * `{ outcome: 'destructive' }` with a reason indistinguishable from a real judgement, so the sweep
+ * read a gate that had given up as a gate that had worked.
+ */
+describe('rateShellCommand — the timeout is configurable, and a timeout says so (EXT-66)', () => {
+  const hangingModel = () => fakeModel(() => new Promise(() => {}));
+
+  it('takes the timeout from approvals config when no option is given', async () => {
+    const { model } = hangingModel();
+    const config = { approvals: { mode: 'full-auto', raterTimeoutMs: 7 } } as unknown as GthConfig;
+    const result = await rateShellCommand('ls -la', config, { model });
+    expect(isRaterTimeout(result), 'the configured budget was honoured').toBe(true);
+    expect(result.reason).toContain('7ms');
+  });
+
+  it('lets an explicit option override the configured budget', async () => {
+    const { model } = hangingModel();
+    const config = {
+      approvals: { mode: 'full-auto', raterTimeoutMs: 900_000 },
+    } as unknown as GthConfig;
+    // Without the override this would hang for fifteen minutes rather than fail the test.
+    const result = await rateShellCommand('ls -la', config, { model, timeoutMs: 4 });
+    expect(result.reason).toContain('4ms');
+  });
+
+  it('falls back to the default when neither is set', async () => {
+    expect(RATER_DEFAULT_TIMEOUT_MS).toBe(30_000);
+    const { model } = hangingModel();
+    const config = { approvals: 'full-auto' } as unknown as GthConfig;
+    // Prove the DEFAULT is what an unset config resolves to, without waiting 30s for it: the
+    // reason names the budget it used, so the resolution is observable without the elapsed time.
+    const raced = await Promise.race([
+      rateShellCommand('ls -la', config, { model }),
+      new Promise((r) => setTimeout(() => r('still-running'), 50)),
+    ]);
+    expect(raced, 'a 30s budget has not elapsed after 50ms').toBe('still-running');
+  });
+
+  /**
+   * The distinction the whole node exists for. All four causes fail CLOSED — that part is correct
+   * and must not move — but they are no longer the same sentence, so a caller can tell an
+   * unanswered gate from a rendered judgement.
+   */
+  it('distinguishes the four fail-closed causes while all four still fail closed', async () => {
+    const causes = ['no-model', 'timeout', 'unparseable', 'threw'] as const;
+    const reasons = new Set(causes.map((c) => failClosedVerdict(c, 1234).reason));
+    expect(reasons.size, 'each cause has its own reason').toBe(causes.length);
+    for (const cause of causes) {
+      const verdict = failClosedVerdict(cause, 1234);
+      expect(verdict.outcome, `${cause} still fails closed`).toBe('destructive');
+      expect(isFailClosed(verdict), `${cause} is recognisable as a gate failure`).toBe(true);
+      expect(
+        mapVerdictToAction('ls -la', verdict, { rung: 'full-auto' }).action,
+        `${cause} never approves and never halts`
+      ).toBe('escalate');
+    }
+    expect(isRaterTimeout(failClosedVerdict('timeout', 1234))).toBe(true);
+    expect(isRaterTimeout(failClosedVerdict('threw'))).toBe(false);
+    expect(isRaterTimeout(failClosedVerdict('unparseable'))).toBe(false);
+    expect(isRaterTimeout(failClosedVerdict('no-model'))).toBe(false);
+  });
+
+  /**
+   * A real rater verdict that happens to be `destructive` must NOT be mistaken for a gate failure.
+   * This is the false-positive direction of `isFailClosed`, and it is the one that would quietly
+   * suppress genuine findings if the predicate were sloppy.
+   */
+  it('does not mistake a real destructive verdict for a gate failure', async () => {
+    const { model } = fakeModel(() => ({
+      outcome: 'destructive',
+      reason: 'Deletes the build directory.',
+    }));
+    const result = await rateShellCommand('rm -rf ./build', CONFIG, { model });
+    expect(result.outcome).toBe('destructive');
+    expect(isFailClosed(result), 'a rendered judgement is not a gate failure').toBe(false);
+    expect(isRaterTimeout(result)).toBe(false);
+  });
+
+  it('legacy FAIL_CLOSED_VERDICT is still recognised as a gate failure', () => {
+    // It remains exported and is still produced by `mapVerdictToAction`'s preflights, so the
+    // predicate must cover it or those paths become invisible the moment anything reads it.
+    expect(isFailClosed(FAIL_CLOSED_VERDICT)).toBe(true);
+    expect(isRaterTimeout(FAIL_CLOSED_VERDICT), 'but it is not a timeout').toBe(false);
   });
 });

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -124,8 +124,15 @@ const APPROVAL_RUNG_VALUES = ['read-only', 'write', 'auto-safe', 'full-auto', 'b
  * - **The scalar form is exactly sugar for `{ "mode": <value> }`** (§9.1). The union exists so the
  *   extras have a home when they are needed, not so there are two ways to say the same thing.
  * - `rater` is a **bare identity-profile name**, not an object (strict resolution, GS2-62: a name
- *   that does not resolve is a hard config error, never a silent fallback). It is the only rater
- *   knob; nesting a one-field object is what this design removed.
+ *   that does not resolve is a hard config error, never a silent fallback).
+ * - `raterTimeoutMs` (EXT-66) is the wall-clock budget for ONE rating call, defaulting to
+ *   `RATER_DEFAULT_TIMEOUT_MS` (30s) at the read site. **It exists because 30s is a hosted-model
+ *   number and a local model is knowably slower**: measured 2026-07-31, `gemma4:12b` over Ollama
+ *   answered a 23-case corpus in 6.0s–114.7s, and at the fixed limit 3 of 18 calls in one run and
+ *   9 of 17 in the next were cut off — so a local `full-auto` session degraded toward escalating
+ *   everything, which is the opposite of what the rung is for. Deliberately a number the user owns
+ *   rather than a provider→timeout table: a table is a guess about someone else's hardware, and
+ *   the failure it causes is silent.
  * - `allow`/`deny` are **read-only input**: merged with the runtime stores the escalation menu
  *   writes, and never written back to config.
  * - The retired `strictness` / `escalate` / `allowlist` / `persistAllowlist` keys and the retired
@@ -145,6 +152,13 @@ const approvalsSchema = z.union([
     rater: z.string().optional(),
     allow: z.array(z.string()).optional(),
     deny: z.array(z.string()).optional(),
+    // EXT-66 — wall-clock budget (ms) for one rating call. See the note on the union above for
+    // why this is a user-owned number rather than a per-provider table.
+    // `.min(1)`, not `.positive()`: the latter emits `exclusiveMinimum`, a JSON-Schema draft
+    // keyword this repo avoids on principle (GS2-57 — Google GenAI rejects it outright in tool
+    // declarations). This schema is not a tool declaration, but one spelling everywhere is what
+    // stops the wrong one being copied into somewhere that is.
+    raterTimeoutMs: z.number().int().min(1).optional(),
   }),
 ]);
 

--- a/packages/core/src/config/shell-policy.ts
+++ b/packages/core/src/config/shell-policy.ts
@@ -469,6 +469,13 @@ export interface ApprovalsObjectConfig {
   allow?: string[];
   /** §3 — declared deny-list: command prefixes never to run. Read-only input; applies under `bypass`. */
   deny?: string[];
+  /**
+   * EXT-66 — wall-clock budget (ms) for ONE rating call. Absent = {@link RATER_DEFAULT_TIMEOUT_MS}
+   * (30s), which is a hosted-model number: a local rater is knowably slower, and when it runs out
+   * of time the gate escalates, so an unreachable timeout turns the permissive rung into one that
+   * asks about everything while every layer reports success.
+   */
+  raterTimeoutMs?: number;
 }
 
 /** On-disk `approvals` value: the rung on its own, or the object when the extras are needed. */
@@ -488,6 +495,12 @@ export interface ResolvedApprovals {
   allow: string[];
   /** Declared deny-list prefixes (§3). Empty when none are declared. */
   deny: string[];
+  /**
+   * EXT-66 — wall-clock budget (ms) for one rating call, or `undefined` to let the rater apply
+   * `RATER_DEFAULT_TIMEOUT_MS`. Left `undefined` rather than defaulted here so the effective-config
+   * snapshot does not churn, exactly as `rater` is.
+   */
+  raterTimeoutMs?: number;
 }
 
 /**
@@ -543,6 +556,7 @@ export function resolveApprovals(
     rater: raw?.rater,
     allow: raw?.allow ?? [],
     deny: raw?.deny ?? [],
+    raterTimeoutMs: raw?.raterTimeoutMs,
   };
 }
 

--- a/packages/core/src/core/GthAgentRunner.ts
+++ b/packages/core/src/core/GthAgentRunner.ts
@@ -21,6 +21,7 @@ import {
   GthRunStats,
   Message,
   PendingToolInterrupt,
+  StatusLevel,
   StatusUpdateCallback,
   ToolApprovalCallback,
   ToolApprovalDecision,
@@ -41,7 +42,9 @@ import {
 } from '#src/core/shell/approvalStop.js';
 import { DenylistStore } from '#src/core/shell/denylist.js';
 import {
+  isRaterTimeout,
   mapVerdictToAction,
+  RATER_DEFAULT_TIMEOUT_MS,
   rateShellCommand,
   type ShellSafetyVerdict,
 } from '#src/core/shell/rater.js';
@@ -126,6 +129,13 @@ export class GthAgentRunner {
    * `undefined` means no profile is configured and the rater uses the session model.
    */
   private raterModel: BaseChatModel | undefined;
+
+  /**
+   * EXT-66 — how many rating calls this session gave up on. Counted so the notice can say "3 times
+   * this session" rather than repeating an identical line, and so a silent drift toward
+   * escalate-everything has a number attached to it.
+   */
+  private raterTimeouts = 0;
 
   private readonly sessionAllowlist = new AllowlistStore();
 
@@ -520,7 +530,27 @@ export class GthAgentRunner {
         // than cached at init, because `/approvals <rung>` moves the rung mid-session and a stale
         // list would offer a tool that is no longer granted.
         grantedTools: this.getGrantedBuiltInTools(),
+        // EXT-66 — the user-owned budget for ONE rating call, `undefined` when unset so
+        // rateShellCommand applies RATER_DEFAULT_TIMEOUT_MS. 30s is a hosted-model number and a
+        // local rater is knowably slower; without this a local `full-auto` session drifts toward
+        // escalating everything, which is the failure the rung exists to prevent.
+        timeoutMs: approvals.raterTimeoutMs,
       });
+      // EXT-66 — a timeout is the gate giving up, not a judgement, and the two were previously
+      // indistinguishable in the action column. Say it once per occurrence: the only symptom
+      // otherwise is the gate becoming mysteriously more talkative, which reads as the rater
+      // working rather than as the rater never being heard from.
+      if (isRaterTimeout(verdict)) {
+        this.raterTimeouts += 1;
+        this.statusUpdate(
+          StatusLevel.WARNING,
+          `The command safety rater did not answer in time (${
+            approvals.raterTimeoutMs ?? RATER_DEFAULT_TIMEOUT_MS
+          }ms), so this command was escalated without being rated` +
+            (this.raterTimeouts > 1 ? ` — ${this.raterTimeouts} times this session` : '') +
+            '. Raise approvals.raterTimeoutMs if the rater is a local model.'
+        );
+      }
       const decision = mapVerdictToAction(command, verdict, { rung: approvals.rung });
       if (decision.action === 'approve') {
         // Scope `once`: rater approvals are NEVER persisted to the allow-list.

--- a/packages/core/src/core/shell/rater.ts
+++ b/packages/core/src/core/shell/rater.ts
@@ -36,7 +36,7 @@ import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import * as z from 'zod';
 
 import type { ApprovalRung, GrantedToolSummary, GthConfig } from '#src/config.js';
-import { isRatedRung } from '#src/config.js';
+import { isRatedRung, resolveApprovals } from '#src/config.js';
 import { classifyCommand } from '#src/core/shell/arity.js';
 import { normalizeCommand } from '#src/core/shell/normalize.js';
 import { findOpenWorldHostLiterals } from '#src/core/shell/openWorld.js';
@@ -145,9 +145,72 @@ export const FAIL_CLOSED_VERDICT: ShellSafetyVerdict = {
 };
 
 /**
+ * EXT-66 — why the gate failed closed. **Every one of these is a fact about the GATE, not about the
+ * command**, which is the whole point of naming them: {@link FAIL_CLOSED_VERDICT} collapsed four
+ * different gate failures into one verdict that reads, downstream and in every eval report, exactly
+ * like a model that looked at the command and judged it `destructive`.
+ *
+ * That is not hypothetical. The EXT-62 anchoring sweep read its first `gemma4:12b` column as full
+ * coverage of the interpreter-wrapper misses; 3 of those escalations were the gate defaulting after
+ * 30 seconds, not the model judging, and only the reason string distinguished them.
+ *
+ * The outcome stays `destructive` for all four — failing closed is right and stays right, and a
+ * failure to assess must not manufacture `catastrophic`/`attack` any more than it may manufacture
+ * an approval. What changes is that the reason now says which failure happened. [[EXT-64]] routes
+ * the `timeout` and `no-model` causes onto its `abstain` ACTION by reading this, rather than
+ * re-deriving it; this module deliberately does not anticipate that vocabulary.
+ */
+export type FailClosedCause = 'no-model' | 'timeout' | 'unparseable' | 'threw';
+
+/**
+ * The fail-closed verdict for a specific {@link FailClosedCause}. Keeps
+ * {@link COULD_NOT_ASSESS_PREFIX} — the statement "this was not assessed" is still true and is what
+ * downstream keys on — and appends what actually went wrong.
+ *
+ * The timeout arm names the budget, because "the rater timed out" is not actionable and "the rater
+ * did not answer within 30000ms" points straight at `approvals.raterTimeoutMs`.
+ */
+export function failClosedVerdict(cause: FailClosedCause, timeoutMs?: number): ShellSafetyVerdict {
+  const detail: Record<FailClosedCause, string> = {
+    'no-model': 'no usable rater model is configured, so nothing evaluated it.',
+    timeout: `the auto-rater did not answer within ${timeoutMs ?? RATER_DEFAULT_TIMEOUT_MS}ms, so nothing evaluated it. This is the gate giving up, not a judgement about the command — raise approvals.raterTimeoutMs if the rater is a local model.`,
+    unparseable: 'the auto-rater returned output that did not match the verdict schema.',
+    threw: 'the auto-rater call failed.',
+  };
+  return { outcome: 'destructive', reason: `${COULD_NOT_ASSESS_PREFIX}: ${detail[cause]}` };
+}
+
+/**
+ * Whether a verdict is one this gate produced because it could not obtain a rating, as opposed to
+ * one a rater actually returned. Keys on {@link COULD_NOT_ASSESS_PREFIX} — the same
+ * reason-prefix-as-identity idiom {@link NAMES_A_HOST_PREFIX} already uses — so it covers the
+ * legacy {@link FAIL_CLOSED_VERDICT} as well as every {@link failClosedVerdict} cause.
+ *
+ * Exported so a caller can tell "the gate defaulted" from "the model judged" without string
+ * matching at the call site, which is the distinction an eval column and a session summary both
+ * need and neither could previously make.
+ */
+export function isFailClosed(verdict: ShellSafetyVerdict | undefined): boolean {
+  return verdict?.reason?.startsWith(COULD_NOT_ASSESS_PREFIX) === true;
+}
+
+/** Whether a verdict is specifically the {@link FailClosedCause} `timeout` arm. */
+export function isRaterTimeout(verdict: ShellSafetyVerdict | undefined): boolean {
+  return isFailClosed(verdict) && verdict?.reason?.includes('did not answer within') === true;
+}
+
+/**
  * Default wall-clock budget (ms) for the rater LLM call. Kept low so a slow/hung rater can't
  * wedge the approval flow — on timeout we fail closed. Mirrors openclaw's low exec-reviewer
  * timeout minimum.
+ *
+ * **EXT-66 — this is a HOSTED-model number, and it is now a default rather than the only value.**
+ * `claude-haiku-4-5` and `gemini-3.6-flash` answered a 23-case corpus well inside it, 0 fail-closed.
+ * `gemma4:12b` over a local GPU took 6.0s–114.7s on the same corpus, and the harder the command the
+ * longer it thought — so the fixed limit preferentially clipped exactly the commands that most
+ * needed rating (3 of 18 calls in one run, 9 of 17 in the next; all of them returned real verdicts
+ * at 120s, including a correct `catastrophic` returned 85 seconds after the gate had given up).
+ * Override with `approvals.raterTimeoutMs`.
  */
 export const RATER_DEFAULT_TIMEOUT_MS = 30_000;
 
@@ -579,7 +642,16 @@ export async function rateShellCommand(
   }
 ): Promise<ShellSafetyVerdict> {
   const model = options?.model ?? config.llm;
-  const timeoutMs = options?.timeoutMs ?? RATER_DEFAULT_TIMEOUT_MS;
+  // EXT-66 — precedence: an explicit option (tests, and `gth eval`'s rater target) wins, then the
+  // user's `approvals.raterTimeoutMs`, then the hosted-model default. Reading the CONFIG here
+  // rather than only the option is what makes a `gth eval` sweep axis of
+  // `config: { approvals: { raterTimeoutMs: … } }` take effect without every caller re-plumbing it
+  // — which matters because a suite could not previously measure a local rater without patching
+  // core, i.e. the one thing you would want to measure was the one thing you could not.
+  const timeoutMs =
+    options?.timeoutMs ??
+    resolveApprovals(config, undefined).raterTimeoutMs ??
+    RATER_DEFAULT_TIMEOUT_MS;
   const { system, user } = buildRaterPrompt(command, {
     home: options?.home,
     grantedTools: options?.grantedTools,
@@ -589,7 +661,7 @@ export async function rateShellCommand(
   try {
     if (!model || typeof model.withStructuredOutput !== 'function') {
       debugLog('rateShellCommand: no usable model for the auto-rater; failing closed.');
-      return FAIL_CLOSED_VERDICT;
+      return failClosedVerdict('no-model');
     }
 
     const structured = model.withStructuredOutput(ShellSafetyVerdictSchema);
@@ -603,7 +675,7 @@ export async function rateShellCommand(
     const raced = await Promise.race([raterPromise, timeoutPromise]);
     if (raced === TIMEOUT) {
       debugLog(`rateShellCommand: rater timed out after ${timeoutMs}ms; failing closed.`);
-      return FAIL_CLOSED_VERDICT;
+      return failClosedVerdict('timeout', timeoutMs);
     }
 
     // withStructuredOutput already coerces to the schema, but re-validate defensively: a fake or
@@ -611,12 +683,12 @@ export async function rateShellCommand(
     const parsed = ShellSafetyVerdictSchema.safeParse(raced);
     if (!parsed.success) {
       debugLog('rateShellCommand: rater returned unparseable output; failing closed.');
-      return FAIL_CLOSED_VERDICT;
+      return failClosedVerdict('unparseable');
     }
     return validateSuggestedTool(parsed.data, options?.grantedTools);
   } catch (error) {
     debugLogError('rateShellCommand', error);
-    return FAIL_CLOSED_VERDICT;
+    return failClosedVerdict('threw');
   } finally {
     if (timer) clearTimeout(timer);
   }


### PR DESCRIPTION
Closes EXT-66.

## Why

The rater's 30s timeout was a hardcoded constant with no config key, and every timeout was laundered into a `destructive` verdict. Two consequences, measured during the EXT-62 anchoring sweep:

- A 12B doing structured output over Ollama takes tens of seconds on a hard command, and the harder the command the longer it thinks — so the timeout preferentially clipped exactly the commands that most needed rating. On `gemma4:12b`, 3 of 18 calls in one run and 9 of 17 in the next hit the wall; at 120s every one of them returned a real verdict, including a correct `catastrophic` that arrived 85 seconds after the gate had given up.
- Because a timed-out call returned `{ outcome: 'destructive' }`, it was indistinguishable — in the action column, in the allow-list logic, and in eval output — from a model that looked at the command and judged it. The first sweep run read as full coverage when 3 of those escalations were the gate defaulting, not the model deciding.

## What changed

The timeout is configurable and honoured by `rateShellCommand`, reachable from a sweep's config axis so an eval against a local rater can measure the thing it is pointed at.

Fail-closed stays fail-closed — the outcome is still `destructive`, which is correct. What changes is that the four causes previously collapsed into one `FAIL_CLOSED_VERDICT` (no usable model, timeout, unparseable output, thrown error) each carry their own honest reason, using the reason-prefix-as-identity idiom the file already established. EXT-64 can then route the timeout cause onto `abstain` by reading a marker that already exists, rather than re-deriving it.

**No second outcome vocabulary is introduced.** `abstain` is EXT-64's, it is an action and never an outcome, and this PR does not anticipate it. The sequencing was decided before implementation and is recorded on the node: this ships first because the hardcoded timeout is a measurement-instrument problem before it is a product problem — EXT-64 would otherwise be evaluated through the very defect this fixes.

## Verification

- build, lint, type-check: clean
- unit: 3791 passed, 3 skipped
- `unit-tests.yml` on this branch: 5/5 cells green, both Windows
- `pnpm run it ollama xx-small`: see comment below

One test here earned its keep: deleting the runner's `timeoutMs` pass-through left the suite green, which read as dead code. It is not — a per-command budget reaches the rater only through the runner. That path now has a test.

Rebased onto `main` after EXT-69 merged; the rebase was clean and the gates above are from the rebased tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAr8tw7cZQg28pr855ErkH
