### PR TITLE
Stop greying fenced code bodies in the TUI markdown renderer

### DIFF
--- a/maintenance/ux-guidelines.md
+++ b/maintenance/ux-guidelines.md
@@ -222,6 +222,11 @@ not chatter (DL-1 no important action is silent). Plain (non-TUI) CLI keeps all 
   and never garbles**: content with no markdown-meaningful syntax passes through verbatim, and any
   internal error returns the original text unchanged. Keep the renderer dependency-light (chalk,
   already shipped by Ink) — don't pull in a heavyweight markdown lib (DL-10).
+- **Fenced code is primary content, not chrome.** Frame fences with **full-width** dim top/bottom
+  rules (same width math as `Rule` / `ruleWidth`; language tag on the top rule when present) and
+  **two-space** indent on body lines. Emit body lines at **default foreground** — do not grey or
+  dim the payload. Greying the body makes committed answers look degraded after stream-plain
+  finishes (DL-7 legibility). Dim is for secondary chrome only.
 - The `--no-tui` / readline path must not import this module; plain/non-interactive output stays
   untouched.
 

--- a/packages/app/spec/tui/markdown.spec.ts
+++ b/packages/app/spec/tui/markdown.spec.ts
@@ -87,14 +87,41 @@ describe('tui markdown renderer', () => {
       expect(out).toContain('2. second');
     });
 
-    it('renders a fenced code block verbatim, dropping the fences', () => {
-      const out = stripAnsi(renderMarkdown('```js\nconst x = 1;\n```'));
-      expect(out).toContain('const x = 1;');
+    it('renders a fenced code block with full-width rules and space indent', () => {
+      const raw = renderMarkdown('```js\nconst x = 1;\n```', { columns: 40 });
+      const out = stripAnsi(raw);
+      const lines = out.split('\n');
       expect(out).not.toContain('```');
+      // Top rule carries the language tag and fills the requested width.
+      expect(lines[0]).toMatch(/^── js ─+$/);
+      expect(lines[0].length).toBe(40);
+      expect(lines[lines.length - 1]).toBe('─'.repeat(40));
+      // Body: two-space indent + verbatim content at default foreground.
+      expect(lines[1]).toBe('  const x = 1;');
+      const bodyRaw = raw.split('\n')[1];
+      expect(bodyRaw).toBe('  const x = 1;'); // no ANSI on the payload line
+    });
+
+    it('frames a fenced block without a language tag at full width', () => {
+      const out = stripAnsi(renderMarkdown('```\nhello\n```', { columns: 24 })).split('\n');
+      expect(out[0]).toBe('─'.repeat(24));
+      expect(out[1]).toBe('  hello');
+      expect(out[2]).toBe('─'.repeat(24));
+    });
+
+    it('does not grey fenced body lines (issue #421)', () => {
+      const raw = renderMarkdown('```\nhello\n```', { columns: 20 });
+      const bodyRaw = raw.split('\n')[1];
+      // Payload stays default fg — no grey/dim wrap on the body line.
+      expect(bodyRaw).toBe('  hello');
+      expect(bodyRaw).not.toBe(chalk.gray('  hello'));
+      expect(bodyRaw).not.toBe(chalk.dim('  hello'));
+      expect(bodyRaw).not.toMatch(/\x1b\[90m/);
+      expect(bodyRaw).not.toMatch(/\x1b\[2m/);
     });
 
     it('does not apply inline formatting inside a fenced block', () => {
-      const out = stripAnsi(renderMarkdown('```\nthis **is not** bold\n```'));
+      const out = stripAnsi(renderMarkdown('```\nthis **is not** bold\n```', { columns: 20 }));
       expect(out).toContain('**is not**'); // markers preserved literally
     });
 

--- a/packages/app/src/tui/markdown.ts
+++ b/packages/app/src/tui/markdown.ts
@@ -1,4 +1,23 @@
 import chalk from 'chalk';
+import { stdout } from '@gaunt-sloth/core/utils/systemUtils.js';
+import { ruleWidth } from '#src/tui/components/Rule.js';
+
+/** Spaces prepended to each fenced body line so the block reads indented vs prose. */
+const FENCE_INDENT = '  ';
+
+/**
+ * Dim full-width rule for fence open/close. Optional language tag sits in the top rule;
+ * remaining columns fill with `─` so the bar matches terminal width (same math as {@link ruleWidth}).
+ */
+function fenceRule(columns: number | undefined, lang?: string): string {
+  const width = ruleWidth(columns);
+  if (lang) {
+    const prefix = `── ${lang} `;
+    const rest = Math.max(1, width - prefix.length);
+    return chalk.dim(prefix + '─'.repeat(rest));
+  }
+  return chalk.dim('─'.repeat(width));
+}
 
 /**
  * Minimal, dependency-light Markdown → ANSI renderer for the Ink TUI.
@@ -92,23 +111,28 @@ const HEADING_COLORS = [
   (s: string) => chalk.bold.dim(s),
 ];
 
+export type RenderMarkdownOptions = {
+  /** Terminal width for full-width fence rules; defaults to `stdout.columns`. */
+  columns?: number;
+};
+
 /**
  * Render a markdown string to an ANSI-styled string suitable for a single Ink `<Text>`.
  * Never throws: on any error, or when the content has no markdown-meaningful syntax, it
  * returns the input unchanged so plain text always reads correctly.
  */
-export function renderMarkdown(text: string): string {
+export function renderMarkdown(text: string, options: RenderMarkdownOptions = {}): string {
   if (!text) return text;
   if (!looksLikeMarkdown(text)) return text;
   try {
-    return renderBlocks(text);
+    return renderBlocks(text, options.columns ?? stdout.columns);
   } catch {
     // Graceful fallback: never garble or crash the transcript.
     return text;
   }
 }
 
-function renderBlocks(text: string): string {
+function renderBlocks(text: string, columns: number | undefined): string {
   const lines = text.split('\n');
   const out: string[] = [];
   let inFence = false;
@@ -117,23 +141,28 @@ function renderBlocks(text: string): string {
   for (const raw of lines) {
     const line = raw;
 
-    // Fenced code blocks: render contents verbatim, dimmed, no inline processing.
+    // Fenced code blocks: drop fence markers; body at default foreground (primary
+    // answer content — do not grey). Distinguish with full-width dim top/bottom rules
+    // and space indentation — no greying of the payload.
     const fenceMatch = /^[ \t]*(```|~~~)(.*)$/.exec(line);
     if (fenceMatch) {
       const marker = fenceMatch[1];
       if (!inFence) {
         inFence = true;
         fenceMarker = marker;
-        continue; // drop the opening fence line (and its language tag)
+        const lang = fenceMatch[2].trim();
+        out.push(fenceRule(columns, lang || undefined));
+        continue;
       }
       if (inFence && marker === fenceMarker) {
         inFence = false;
         fenceMarker = '';
-        continue; // drop the closing fence line
+        out.push(fenceRule(columns));
+        continue;
       }
     }
     if (inFence) {
-      out.push(chalk.gray(line));
+      out.push(`${FENCE_INDENT}${line}`);
       continue;
     }
 


### PR DESCRIPTION
## Summary
- Stop wrapping fenced code body lines in `chalk.gray` so committed answers stay full-brightness after streaming finishes (issue #421).
- Frame fences with full-width dim top/bottom rules (language tag on the top rule) and a two-space body indent; payload stays default foreground.
- Document the rule in UX guidelines and extend unit coverage for width, indent, and non-grey body lines.

## Test plan
- [x] Unit tests in `packages/app/spec/tui/markdown.spec.ts` cover full-width rules, indent, no language tag, and no grey/dim on body
- [x] Manually verify TUI transcript: fenced code looks crisp after stream settles; rules span terminal width
- [x] Sanity-check a block with and without a language tag, plus inline markdown markers left literal inside fences