### PR TITLE
Pass the PR id from the review CLI so its GitHub tools can address the PR

### DIFF
--- a/packages/review/cli.js
+++ b/packages/review/cli.js
@@ -29,6 +29,7 @@ import {
   getContentFromSource,
   getRequirementsFromSource,
   getReviewPreamble,
+  resolvePrIdFromArg,
 } from '#src/commands/commandUtils.js';
 
 async function main() {
@@ -65,7 +66,11 @@ async function main() {
       ? `Requirements:\n${requirements}\nDiff:\n${content}`
       : content;
 
-    await review('pr-review', preambleText, diffWithReqs, config, 'pr');
+    // Pass the PR id on so GitHub-only tools address the PR explicitly instead of trying to
+    // resolve it from the checked-out branch, which a CI runner's detached HEAD cannot provide.
+    await review('pr-review', preambleText, diffWithReqs, config, 'pr', undefined, {
+      prId: resolvePrIdFromArg(contentArg),
+    });
   } catch (error) {
     displayError(error instanceof Error ? error.message : String(error));
     process.exit(1);

--- a/packages/review/spec/resolvePrIdFromArg.spec.ts
+++ b/packages/review/spec/resolvePrIdFromArg.spec.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('resolvePrIdFromArg', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('reads a PR id out of a bare number', async () => {
+    const { resolvePrIdFromArg } = await import('#src/commands/commandUtils.js');
+
+    expect(resolvePrIdFromArg('123')).toBe('123');
+  });
+
+  it('returns undefined when there is no argument, so branch discovery still applies', async () => {
+    const { resolvePrIdFromArg } = await import('#src/commands/commandUtils.js');
+
+    expect(resolvePrIdFromArg(undefined)).toBeUndefined();
+  });
+
+  it('treats non-numeric content as content rather than a PR id', async () => {
+    const { resolvePrIdFromArg } = await import('#src/commands/commandUtils.js');
+
+    // The same positional argument carries literal content in the non-GitHub flows.
+    expect(resolvePrIdFromArg('diff --git a/x b/x')).toBeUndefined();
+    expect(resolvePrIdFromArg('src/index.ts')).toBeUndefined();
+    expect(resolvePrIdFromArg('')).toBeUndefined();
+  });
+
+  it('rejects anything a number is only part of, so nothing but digits reaches a command', async () => {
+    const { resolvePrIdFromArg } = await import('#src/commands/commandUtils.js');
+
+    expect(resolvePrIdFromArg('123; rm -rf /')).toBeUndefined();
+    expect(resolvePrIdFromArg('#123')).toBeUndefined();
+    expect(resolvePrIdFromArg(' 123')).toBeUndefined();
+    expect(resolvePrIdFromArg('123\n')).toBeUndefined();
+  });
+});

--- a/packages/review/src/commands/commandUtils.ts
+++ b/packages/review/src/commands/commandUtils.ts
@@ -85,6 +85,22 @@ export async function getContentFromSource(
   );
 }
 
+/** A PR id is a bare number; anything else is literal content (a diff, a file path, text). */
+const PR_ID_PATTERN = /^\d+$/;
+
+/**
+ * Reads a PR id out of the CLI's first positional argument, which is a PR number in the GitHub
+ * flow and arbitrary content otherwise.
+ *
+ * The id binds GitHub-only review tools to the PR under review. Without it they fall back to
+ * resolving the PR from the checked-out branch, which no CI runner has: the standard checkout
+ * actions leave the workspace on a detached HEAD, so the fallback cannot succeed there and the
+ * tools degrade to unavailable.
+ */
+export function resolvePrIdFromArg(contentArg: string | undefined): string | undefined {
+  return contentArg !== undefined && PR_ID_PATTERN.test(contentArg) ? contentArg : undefined;
+}
+
 async function getFromSource(
   source: RequirementSourceType | ContentSourceType | undefined,
   id: string | undefined,


### PR DESCRIPTION
## The bug

`packages/review/cli.js` calls the review module with five arguments and never passes a `reviewContext`, so `prId` is always `undefined`:

```js
await review('pr-review', preambleText, diffWithReqs, config, 'pr');
```

`resolvePrRepoContext()` in `ghReadFileTool.ts` then builds its command with an empty PR selector, which makes `gh` resolve the PR from the checked-out branch:

```ts
const prSelector = prId ? ` ${prId}` : '';
const ghCommand = `gh pr view${prSelector} --json headRefName,headRepository,headRepositoryOwner`;
```

**A CI runner has no current branch.** `actions/checkout` leaves the workspace on a detached HEAD at the merge commit, so the fallback cannot succeed there. Every run reports:

```
Could not resolve the pull request repository via the GitHub API: Command failed: gh pr view --json headRefName,headRepository,headRepositoryOwner
could not determine current branch: failed to run git: not on any branch
```

So `gth_gh_read_file` is unavailable for the whole review — the REL-2 tool cannot fetch the full contents of a file when the diff truncates a large change, which is the only reason it exists. The failure is quiet: the tool returns its explanation to the agent, the review continues on the truncated diff, and the tool call still reads as successful in the output.

It is not a permissions problem, which is the wrong conclusion the current message invites. The PR number *is* available to the process — `getContentFromSource` already used it to fetch the diff through the same token — and the tool reads through `gh api repos/…/contents/…`, covered by a workflow's `contents: read`. No token scope changes anything here.

## The fix

The CLI already receives the PR number as its first positional argument, so pass it through as `prId`. The tools then address the PR explicitly and never consult a branch.

The same positional argument carries literal content in the non-GitHub flows (a diff, a file path, text), so only a bare number becomes an id. `resolvePrIdFromArg()` is a named export rather than an inline test because `cli.js` is an untested entry point, and the argument-shape decision is the part worth pinning.

Anything a number is only part of — `#123`, `123; rm -rf /`, ` 123`, `123\n` — resolves to no id. That keeps `PR_ID_PATTERN`'s guarantee that nothing but digits can reach `execAsync`, and leaves branch discovery in place for interactive `gth pr` use, where a current branch does exist.

## Verification

Build, unit suite and lint are green: **5899 passed**, 3 skipped, 286 files; `pnpm run lint` clean at `--max-warnings 0`. The four new cases in `packages/review/spec/resolvePrIdFromArg.spec.ts` pass.

The mechanism itself was confirmed directly against a detached HEAD, which is the state a runner is in:

```
$ git branch --show-current        # (empty — detached)

$ gh pr view --json headRefName,headRepository,headRepositoryOwner
could not determine current branch: failed to run git: not on any branch

$ gh pr view <n> --json headRefName,headRepository,headRepositoryOwner
{"headRefName":"...","headRepository":{...},"headRepositoryOwner":{...}}
```

Same directory, same auth — the only difference is the explicit id.

## Not included

- **The error message.** Leading with the `gh` auth advice sends diagnosis the wrong way, since the actual cause is on the line above it. Worth rewording, but the discovery fallback stays legitimate for interactive use, so the message is not wrong — just badly ordered. Separate change.
- **Release notes.** `RELEASE-NOTES-HOWTO.md` makes those a release-time artifact written from the tag diff and confirmed with the maintainer, so no file is added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
